### PR TITLE
fix write single register

### DIFF
--- a/src/source_drivers/modbus/services/modbus_functions/function_utils.py
+++ b/src/source_drivers/modbus/services/modbus_functions/function_utils.py
@@ -83,13 +83,13 @@ def _builder_data_type(payload, data_type: ModbusDataType, byteorder: Endian, wo
     """
     builder = BinaryPayloadBuilder(byteorder=byteorder, wordorder=word_order)
     if data_type == ModbusDataType.INT16:
-        builder.add_16bit_int(payload)
+        builder.add_16bit_int(int(payload))
     if data_type == ModbusDataType.UINT16:
-        builder.add_16bit_uint(payload)
+        builder.add_16bit_uint(int(payload))
     if data_type == ModbusDataType.INT32:
-        builder.add_32bit_int(payload)
+        builder.add_32bit_int(int(payload))
     if data_type == ModbusDataType.UINT32:
-        builder.add_32bit_uint(payload)
+        builder.add_32bit_uint(int(payload))
     if data_type == ModbusDataType.FLOAT:
         builder.add_32bit_float(payload)
     elif data_type == ModbusDataType.DOUBLE:

--- a/src/source_drivers/modbus/services/modbus_functions/polling/functions.py
+++ b/src/source_drivers/modbus/services/modbus_functions/polling/functions.py
@@ -130,10 +130,11 @@ def write_analogue(client, reg_start: int, reg_length: int, _unit: int, data_typ
     debug_log('write_analogue', _unit, func, reg_length, reg_start)
     reg_length = _set_data_length(data_type, reg_length)
     byteorder, word_order = _mod_point_data_endian(endian)
-    payload = _builder_data_type(write_value, data_type, byteorder, word_order)
     if func == ModbusFunctionCode.WRITE_REGISTER:
-        write = client.write_register(reg_start, payload, unit=_unit)
+        payload = [int(write_value)]
+        write = client.write_register(reg_start, int(write_value), unit=_unit)
     elif func == ModbusFunctionCode.WRITE_REGISTERS:
+        payload = _builder_data_type(write_value, data_type, byteorder, word_order)
         write = client.write_registers(reg_start, payload, unit=_unit)
     else:
         raise Exception('Invalid Modbus function code', func)


### PR DESCRIPTION
```
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/home/dan/rubix-point-server/src/source_drivers/modbus/services/modbus_polling.py", line 40, in polling
    self.__poll()
  File "/home/dan/rubix-point-server/src/source_drivers/modbus/services/modbus_polling.py", line 86, in __poll
    self.__poll_point(current_connection, point, device, network, True)
  File "/home/dan/rubix-point-server/src/source_drivers/modbus/services/modbus_polling.py", line 135, in __poll_point
    point_store = poll_point(self, connection, network, device, point, update_point_store)
  File "/home/dan/rubix-point-server/src/source_drivers/modbus/services/modbus_functions/polling/poll.py", line 100, in poll_point
    val, array = write_analogue(connection,
  File "/home/dan/rubix-point-server/src/source_drivers/modbus/services/modbus_functions/polling/functions.py", line 133, in write_analogue
    payload = _builder_data_type(write_value, data_type, byteorder, word_order)
  File "/home/dan/rubix-point-server/src/source_drivers/modbus/services/modbus_functions/function_utils.py", line 86, in _builder_data_type
    builder.add_16bit_int(payload)
  File "/home/dan/rubix-point-server/venv/lib/python3.8/site-packages/pymodbus/payload.py", line 213, in add_16bit_int
    self._payload.append(pack(fstring, value))
struct.error: required argument is not an integer

Process finished with exit code 0
```