### PR TITLE
Copy logging file when it doesn't exist

### DIFF
--- a/script.bash
+++ b/script.bash
@@ -22,7 +22,7 @@ CONFIG_EXAMPLE=settings/config.example.ini
 CONFIG=config.ini
 
 LOGGING_EXAMPLE=logging/logging.example.conf
-LOGGING=logging/logging.conf
+LOGGING=logging.conf
 
 createDirIfNotExist() {
     mkdir -p ${DATA_DIR}
@@ -31,7 +31,7 @@ createDirIfNotExist() {
 
 copyConfigurationIfNotExist() {
     if [ ! -s ${DATA_DIR}/${CONFIG} ]; then
-        echo -e "${RED}config.ini file doesn't exist (or it is empty)${DEFAULT}"
+        echo -e "${RED}${CONFIG} file doesn't exist (or it is empty)${DEFAULT}"
         cp ${WORKING_DIR}/${CONFIG_EXAMPLE} ${DATA_DIR}/${CONFIG}
         sudo chmod -R +755 ${DATA_DIR}/${CONFIG}
     fi
@@ -39,7 +39,7 @@ copyConfigurationIfNotExist() {
 
 copyLoggingIfNotExist() {
     if [ ! -s ${DATA_DIR}/${LOGGING} ]; then
-        echo -e "${RED}logging.ini file doesn't exist (or it is empty)${DEFAULT}"
+        echo -e "${RED}${LOGGING} file doesn't exist (or it is empty)${DEFAULT}"
         cp ${WORKING_DIR}/${LOGGING_EXAMPLE} ${DATA_DIR}/${LOGGING}
         sudo chmod -R +755 ${DATA_DIR}/${LOGGING}
     fi
@@ -92,6 +92,7 @@ start() {
     if [[ ${USER} != "" && ${WORKING_DIR} != "" && ${LIB_DIR} != "" ]]; then
         createDirIfNotExist
         copyConfigurationIfNotExist
+        copyLoggingIfNotExist
         createLinuxService
         startNewLinuxService
         echo -e "${GREEN}Service is created and started.${DEFAULT}"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,3 @@
-import logging.config
 import os
 
 from flask import Flask
@@ -10,7 +9,10 @@ from sqlalchemy import event
 from src.event_dispatcher import EventDispatcher
 
 try:
-    logging.config.fileConfig('logging/logging.conf')
+    if os.environ.get("data_dir") is None:
+        filename = 'logging/logging.conf'
+    else:
+        filename = os.path.join(os.environ.get("data_dir"), 'logging.conf')
 except Exception as e:
     raise Exception('Failed to load logging config file. Assure the example config is cloned as logging.conf')
 
@@ -32,6 +34,7 @@ else:
         url = f'sqlite:///{os.environ.get("data_dir")}/data.db?timeout=60'
 
     app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL', url)
+
 
     @event.listens_for(Engine, "connect")
     def set_sqlite_pragma(dbapi_connection, connection_record):


### PR DESCRIPTION
On automation, we can't leave that logging.conf blank so we are copying it from example.