### PR TITLE
point_store timestamp improvement

### DIFF
--- a/src/resources/rest_schema/schema_point.py
+++ b/src/resources/rest_schema/schema_point.py
@@ -9,7 +9,8 @@ point_store_fields = {
     'value_raw': fields.String,
     'fault': fields.Boolean,
     'fault_message': fields.String,
-    'ts': fields.String
+    'ts_value': fields.String,
+    'ts_fault': fields.String
 }
 
 point_all_attributes = {

--- a/src/services/mqtt_client/mqtt_client.py
+++ b/src/services/mqtt_client/mqtt_client.py
@@ -54,12 +54,19 @@ class MqttClient(MqttClientBase, EventServiceBase):
         topic = self.make_topic((self.config.topic, MQTT_TOPIC_COV, MQTT_TOPIC_COV_ALL, point.uuid, point.name,
                                  device_uuid, device_name, network_uuid, network_name, source_driver))
 
-        payload = {
-            'value': point_store.value,
-            'value_raw': point_store.value_raw,
-            'fault': point_store.fault,
-            'fault_message': point_store.fault_message,
-        }
+        if point_store.fault:
+            payload = {
+                'fault': point_store.fault,
+                'fault_message': point_store.fault_message,
+                'ts': point_store.ts_fault,
+            }
+        else:
+            payload = {
+                'fault': point_store.fault,
+                'value': point_store.value,
+                'value_raw': point_store.value_raw,
+                'ts': point_store.ts_value,
+            }
 
         logger.debug(f'MQTT PUB: {self.to_string()} {topic} > {payload}')
         self._client.publish(topic, json.dumps(payload), self.config.qos, self.config.retain)

--- a/src/utils/model_utils.py
+++ b/src/utils/model_utils.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 class ModelUtils:
     @staticmethod
     def row2dict(row):
@@ -17,3 +18,14 @@ class ModelUtils:
             attr = getattr(row, column.name)
             d[column.name] = attr
         return d
+
+
+def get_datetime() -> datetime:
+    return datetime.now()
+
+
+def datetime_to_str(datetime_obj: datetime or None) -> str:
+    if datetime_obj is not None:
+        return datetime_obj.strftime("%Y-%m-%d %H:%M:%S")
+    else:
+        return datetime.now().strftime("%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
- changed `point_store` `ts` to 
    - `ts_value` for last COV
    - `ts_fault` for last fault
- mqtt COV payload now has two versions (**Note**: both payloads have just `ts` for the timestamp key)
    - fault
        ```
        payload = {
                'fault': point_store.fault,
                'fault_message': point_store.fault_message,
                'ts': point_store.ts_fault,
        }
        ```
    - value
        ```
        payload = {
                'fault': point_store.fault,
                'value': point_store.value,
                'value_raw': point_store.value_raw,
                'ts': point_store.ts_value,
        }
        ```