### PR TITLE
fix point_store on point update

### DIFF
--- a/src/models/point/model_point.py
+++ b/src/models/point/model_point.py
@@ -90,7 +90,7 @@ class PointModel(ModelBase):
         super().update(**kwargs)
 
         point_store: PointStoreModel = PointStoreModel.find_by_point_uuid(self.uuid)
-        updated = point_store.update(0)
+        updated = self.update_point_value(point_store, 0)
         self.point_store = point_store
         if updated:
             self.publish_cov(self.point_store)

--- a/src/models/point/model_point_store.py
+++ b/src/models/point/model_point_store.py
@@ -55,8 +55,8 @@ class PointStoreModel(PointStoreModelMixin, db.Model):
                                 or_(self.__table__.c.value == None,
                                     db.func.abs(self.__table__.c.value - self.value) >= cov_threshold,
                                     self.__table__.c.fault != self.fault))))
-            if res.rowcount:
-                self.ts_value = datetime_to_str(ts)
+            if res.rowcount:  # WARNING: this could cause secondary write to db is store if fetched/linked from DB
+                self.ts_value = ts
         else:
             res = db.session.execute(
                 self.__table__
@@ -67,7 +67,7 @@ class PointStoreModel(PointStoreModelMixin, db.Model):
                     .where(and_(self.__table__.c.point_uuid == self.point_uuid,
                                 or_(self.__table__.c.fault != self.fault,
                                     self.__table__.c.fault_message != self.fault_message))))
-            if res.rowcount:
-                self.ts_fault = datetime_to_str(ts)
+            if res.rowcount:  # WARNING: this could cause secondary write to db is store if fetched/linked from DB
+                self.ts_fault = ts
         db.session.commit()
         return bool(res.rowcount)

--- a/src/services/mqtt_client/mqtt_client.py
+++ b/src/services/mqtt_client/mqtt_client.py
@@ -8,6 +8,7 @@ from src.models.point.model_point_store import PointStoreModel
 from src.services.event_service_base import EventServiceBase, Event, EventType
 from .mqtt_client_base import MqttClientBase
 from .mqtt_registry import MqttRegistry
+from src.utils.model_utils import datetime_to_str
 
 
 logger = logging.getLogger(__name__)
@@ -67,7 +68,8 @@ class MqttClient(MqttClientBase, EventServiceBase):
                 'value_raw': point_store.value_raw,
                 'ts': point_store.ts_value,
             }
-
+        if not isinstance(payload['ts'], str):
+            payload['ts'] = datetime_to_str(payload['ts'])
         logger.debug(f'MQTT PUB: {self.to_string()} {topic} > {payload}')
         self._client.publish(topic, json.dumps(payload), self.config.qos, self.config.retain)
         if self.config.publish_value and not point_store.fault:


### PR DESCRIPTION
2 fixes on `point` `PATCH`
- `point` was not applying new offsets and scaling to `point_store`
- fix `point_store` timestamp error for MQTT publish when timestamp is datetime object and not string