### PR TITLE
Include points child filter

### DIFF
--- a/src/resources/resource_network.py
+++ b/src/resources/resource_network.py
@@ -2,12 +2,15 @@ from flask_restful import Resource, abort
 from flask_restful.reqparse import request
 
 from src.models.network.model_network import NetworkModel
-from src.resources.rest_schema.schema_network import network_all_fields, network_all_fields_with_children
-from src.resources.utils import model_marshaller_with_children
+from src.resources.rest_schema.schema_network import network_all_fields, network_all_fields_with_children, \
+    network_all_fields_without_point_children
+from src.resources.utils import model_network_marshaller
 
 
 def network_marshaller(data: any, args: dict):
-    return model_marshaller_with_children(data, args, network_all_fields, network_all_fields_with_children)
+    return model_network_marshaller(data, args, network_all_fields,
+                                    network_all_fields_without_point_children,
+                                    network_all_fields_with_children)
 
 
 class NetworkResource(Resource):

--- a/src/resources/rest_schema/schema_network.py
+++ b/src/resources/rest_schema/schema_network.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from flask_restful import fields
 
 from src.resources.utils import map_rest_schema
-from src.resources.rest_schema.schema_device import device_all_fields_with_children
+from src.resources.rest_schema.schema_device import device_all_fields_with_children, device_all_fields
 
 network_all_attributes = {
     'name': {
@@ -41,8 +41,8 @@ network_all_fields = {}
 map_rest_schema(network_return_attributes, network_all_fields)
 map_rest_schema(network_all_attributes, network_all_fields)
 
-network_all_fields_with_children_base = {
-    'devices': fields.List(fields.Nested(device_all_fields_with_children))
-}
 network_all_fields_with_children = deepcopy(network_all_fields)
-network_all_fields_with_children.update(network_all_fields_with_children_base)
+network_all_fields_with_children['devices'] = fields.List(fields.Nested(device_all_fields_with_children))
+
+network_all_fields_without_point_children = deepcopy(network_all_fields)
+network_all_fields_without_point_children['devices'] = fields.List(fields.Nested(device_all_fields))

--- a/src/resources/utils.py
+++ b/src/resources/utils.py
@@ -4,6 +4,27 @@ from flask_restful import fields
 from flask_restful import abort, marshal
 
 
+def model_network_marshaller(data: any, args: dict, base_fields: dict, children_without_point_fields: dict,
+                             children_fields: dict):
+    with_children = False
+    points = False
+    try:
+        if 'with_children' in args:
+            with_children = bool(strtobool(args['with_children']))
+        if 'points' in args:
+            points = bool(strtobool(args['points']))
+    except:
+        abort(400, message='Invalid query string')
+
+    if with_children:
+        if points:
+            return marshal(data, children_fields)
+        else:
+            return marshal(data, children_without_point_fields)
+    else:
+        return marshal(data, base_fields)
+
+
 def model_marshaller_with_children(data: any, args: dict, base_fields: dict, children_fields: dict):
     with_children = False
     if 'with_children' in args:

--- a/src/source_drivers/generic/resources/network/network_base.py
+++ b/src/source_drivers/generic/resources/network/network_base.py
@@ -1,15 +1,17 @@
 from flask_restful import Resource, abort, reqparse
 from sqlalchemy.exc import IntegrityError
 
+from src.resources.utils import model_network_marshaller
 from src.source_drivers.generic.models.network import GenericNetworkModel
 from src.source_drivers.generic.resources.rest_schema.schema_generic_network import generic_network_all_attributes, \
-    generic_network_all_fields, generic_network_all_fields_with_children
-from src.resources.utils import model_marshaller_with_children
+    generic_network_all_fields, generic_network_all_fields_with_children, \
+    generic_network_all_fields_without_point_children
 
 
 def generic_network_marshaller(data: any, args: dict):
-    return model_marshaller_with_children(data, args, generic_network_all_fields,
-                                          generic_network_all_fields_with_children)
+    return model_network_marshaller(data, args, generic_network_all_fields,
+                                    generic_network_all_fields_without_point_children,
+                                    generic_network_all_fields_with_children)
 
 
 class GenericNetworkBase(Resource):

--- a/src/source_drivers/generic/resources/rest_schema/schema_generic_network.py
+++ b/src/source_drivers/generic/resources/rest_schema/schema_generic_network.py
@@ -1,6 +1,6 @@
 from src.resources.rest_schema.schema_network import *
 from src.source_drivers.generic.resources.rest_schema.schema_generic_device import \
-    generic_device_all_fields_with_children
+    generic_device_all_fields_with_children, generic_device_all_fields
 
 generic_network_all_attributes = deepcopy(network_all_attributes)
 
@@ -11,6 +11,8 @@ map_rest_schema(generic_network_return_attributes, generic_network_all_fields)
 map_rest_schema(generic_network_all_attributes, generic_network_all_fields)
 
 generic_network_all_fields_with_children = deepcopy(generic_network_all_fields)
-generic_network_all_fields_with_children.update(network_all_fields_with_children_base)
 generic_network_all_fields_with_children['devices'] = fields.List(fields.Nested(
     generic_device_all_fields_with_children))
+
+generic_network_all_fields_without_point_children = deepcopy(generic_network_all_fields)
+generic_network_all_fields_without_point_children['devices'] = fields.List(fields.Nested(generic_device_all_fields))

--- a/src/source_drivers/modbus/resources/network/network_base.py
+++ b/src/source_drivers/modbus/resources/network/network_base.py
@@ -1,15 +1,17 @@
 from flask_restful import Resource, abort, reqparse
 from sqlalchemy.exc import IntegrityError
 
+from src.resources.utils import model_network_marshaller
 from src.source_drivers.modbus.models.network import ModbusNetworkModel
 from src.source_drivers.modbus.resources.rest_schema.schema_modbus_network import modbus_network_all_attributes, \
-    modbus_network_all_fields, modbus_network_all_fields_with_children
-from src.resources.utils import model_marshaller_with_children
+    modbus_network_all_fields, modbus_network_all_fields_with_children, \
+    modbus_network_all_fields_without_points_children
 
 
 def modbus_network_marshaller(data: any, args: dict):
-    return model_marshaller_with_children(data, args, modbus_network_all_fields,
-                                          modbus_network_all_fields_with_children)
+    return model_network_marshaller(data, args, modbus_network_all_fields,
+                                    modbus_network_all_fields_without_points_children,
+                                    modbus_network_all_fields_with_children)
 
 
 class ModbusNetworkBase(Resource):

--- a/src/source_drivers/modbus/resources/rest_schema/schema_modbus_network.py
+++ b/src/source_drivers/modbus/resources/rest_schema/schema_modbus_network.py
@@ -1,5 +1,6 @@
 from src.resources.rest_schema.schema_network import *
-from src.source_drivers.modbus.resources.rest_schema.schema_modbus_device import modbus_device_all_fields_with_children
+from src.source_drivers.modbus.resources.rest_schema.schema_modbus_device import modbus_device_all_fields_with_children, \
+    modbus_device_all_fields
 
 modbus_network_all_attributes = deepcopy(network_all_attributes)
 modbus_network_all_attributes['type'] = {
@@ -42,5 +43,7 @@ map_rest_schema(modbus_network_return_attributes, modbus_network_all_fields)
 map_rest_schema(modbus_network_all_attributes, modbus_network_all_fields)
 
 modbus_network_all_fields_with_children = deepcopy(modbus_network_all_fields)
-modbus_network_all_fields_with_children.update(network_all_fields_with_children_base)
 modbus_network_all_fields_with_children['devices'] = fields.List(fields.Nested(modbus_device_all_fields_with_children))
+
+modbus_network_all_fields_without_points_children = deepcopy(modbus_network_all_fields)
+modbus_network_all_fields_without_points_children['devices'] = fields.List(fields.Nested(modbus_device_all_fields))


### PR DESCRIPTION
Resolves: #175

### Summary:
- Include points child filter. Examples:
   - http://localhost:1515/api/networks/uuid/<network_uuid>?with_children=true&points=true (By default points=false)
   - http://localhost:1515/api/modbus/networks/<network_uuid>?with_children=true&points=true (By default points=false)
   - http://localhost:1515/api/generic/networks/<network_uuid>?with_children=true&points=true (By default points=false)
   - http://localhost:1515/api/networks?with_children=true&points=true (By default points=false)