### PR TITLE
PATCH generic value support

### DIFF
--- a/src/resources/rest_schema/schema_point.py
+++ b/src/resources/rest_schema/schema_point.py
@@ -37,10 +37,13 @@ point_all_attributes = {
     'history_interval': {
         'type': int,
     },
-    'cov_threshold': {
-        'type': float,
+    'writable': {
+        'type': bool,
     },
     'write_value': {
+        'type': float,
+    },
+    'cov_threshold': {
         'type': float,
     },
     'value_round': {

--- a/src/routes.py
+++ b/src/routes.py
@@ -11,6 +11,7 @@ from src.source_drivers.generic.resources.network.network_plural import GenericN
 from src.source_drivers.generic.resources.network.network_singular import GenericNetworkSingular
 from src.source_drivers.generic.resources.point.point_plural import GenericPointPlural
 from src.source_drivers.generic.resources.point.point_singular import GenericPointSingular
+from src.source_drivers.generic.resources.point.point_value_writer import GenericPointValueWriter
 from src.source_drivers.modbus.resources.device.device_plural import ModbusDevicePlural
 from src.source_drivers.modbus.resources.device.device_singular import ModbusDeviceSingular
 from src.source_drivers.modbus.resources.network.network_plural import ModbusNetworkPlural
@@ -49,6 +50,7 @@ api_generic.add_resource(GenericDevicePlural, '/devices')
 api_generic.add_resource(GenericDeviceSingular, '/devices/<string:uuid>')
 api_generic.add_resource(GenericPointPlural, '/points')
 api_generic.add_resource(GenericPointSingular, '/points/<string:uuid>')
+api_generic.add_resource(GenericPointValueWriter, '/points/<string:uuid>/value')
 
 bp_modbus = Blueprint('modbus', __name__, url_prefix='/api/modbus')
 api_modbus = Api(bp_modbus)

--- a/src/source_drivers/generic/resources/point/point_value_writer.py
+++ b/src/source_drivers/generic/resources/point/point_value_writer.py
@@ -1,0 +1,28 @@
+from flask_restful import Resource, reqparse, abort
+
+from src.models.point.model_point import PointModel
+
+
+class GenericPointValueWriter(Resource):
+    patch_parser = reqparse.RequestParser()
+    patch_parser.add_argument('value', type=float, required=True)
+    patch_parser.add_argument('value_raw', type=float, required=False)
+    patch_parser.add_argument('fault', type=bool, required=False)
+    patch_parser.add_argument('fault_message', type=str, required=False)
+
+    @classmethod
+    def patch(cls, uuid):
+        data = GenericPointValueWriter.patch_parser.parse_args()
+        point: PointModel = PointModel.find_by_uuid(uuid)
+        if not point:
+            abort(404, message=f'Does not exist {uuid}')
+        if not point.writable:
+            abort(400, message=f'Is not writable {uuid}')
+        try:
+            point.update_point_store(value=data.get('value'),
+                                     value_raw=data.get('value_raw') if data.get('value_raw') else data.get('value'),
+                                     fault=data.get('fault'),
+                                     fault_message=data.get('fault_message'))
+            return {}
+        except Exception as e:
+            abort(501, message=str(e))


### PR DESCRIPTION
Resolves: #189
Resolves: #187

### Summary:

Made an `PATCH` API available for POSTing value for Generic writable points. URL endpoint example:

```bash
curl -X PATCH http://localhost:1515/api/generic/points/<uuid>/value -H "Content-Type: application/json" -d '{"value": <value>, ...}'
```