### PR TITLE
Fix/polling crash

### DIFF
--- a/src/source_drivers/modbus/models/point.py
+++ b/src/source_drivers/modbus/models/point.py
@@ -1,9 +1,9 @@
-from sqlalchemy.orm import validates
 from sqlalchemy import UniqueConstraint
+from sqlalchemy.orm import validates
 
 from src import db
-from src.source_drivers import MODBUS_SERVICE_NAME
 from src.models.point.model_point_mixin import PointMixinModel
+from src.source_drivers import MODBUS_SERVICE_NAME
 from src.source_drivers.modbus.interfaces.point.points import ModbusFunctionCode, ModbusDataType, ModbusDataEndian
 
 
@@ -45,12 +45,15 @@ class ModbusPointModel(PointMixinModel):
 
     @validates('function_code')
     def validate_function_code(self, _, value):
+        if not self.write_value and value in [ModbusFunctionCode.WRITE_COIL, ModbusFunctionCode.WRITE_COILS,
+                                              ModbusFunctionCode.WRITE_REGISTER, ModbusFunctionCode.WRITE_REGISTERS]:
+            raise ValueError(f"write_value shouldn't be null for {self.function_code}")
         if isinstance(value, ModbusFunctionCode):
             return value
         elif isinstance(value, int):
             try:
                 return ModbusFunctionCode(value)
-            except:
+            except Exception:
                 raise ValueError("Invalid function code")
         elif not value or value not in ModbusFunctionCode.__members__:
             raise ValueError("Invalid function code")

--- a/src/source_drivers/modbus/services/modbus_functions/polling/functions.py
+++ b/src/source_drivers/modbus/services/modbus_functions/polling/functions.py
@@ -25,7 +25,7 @@ def read_analogue(client, reg_start: int, reg_length: int, _unit: int, data_type
     :return: tuple (val: any, array: list)
     """
     debug_log('read_analogue', _unit, func, reg_length, reg_start)
-    reg_length = _set_data_length(data_type, reg_length)
+    reg_length: int = _set_data_length(data_type, reg_length)
     if func == ModbusFunctionCode.READ_HOLDING_REGISTERS:
         read = client.read_holding_registers(reg_start, reg_length, unit=_unit)
     elif func == ModbusFunctionCode.READ_INPUT_REGISTERS:
@@ -58,7 +58,7 @@ def read_digital(client, reg_start: int, reg_length: int, _unit: int, func: Modb
     :return: tuple (val: any, array: list)
     """
     debug_log('read_digital', _unit, func, reg_length, reg_start)
-    reg_length = _set_data_length(ModbusDataType.DIGITAL, reg_length)
+    reg_length: int = _set_data_length(ModbusDataType.DIGITAL, reg_length)
     if func == ModbusFunctionCode.READ_COILS:
         read = client.read_coils(reg_start, reg_length, unit=_unit)
     elif func == ModbusFunctionCode.READ_DISCRETE_INPUTS:
@@ -91,8 +91,8 @@ def write_digital(client, reg_start: int, reg_length: int, _unit: int,
     :return: tuple (val: any, array: list)
     """
     debug_log('write_digital', _unit, func, reg_length, reg_start)
-    data_type = 'digital'
-    reg_length = _set_data_length(data_type, reg_length)
+    data_type: ModbusDataType = ModbusDataType.DIGITAL
+    reg_length: int = _set_data_length(data_type, reg_length)
     if func == ModbusFunctionCode.WRITE_COIL:
         write = client.write_coil(reg_start, write_value, unit=_unit)
     elif func == ModbusFunctionCode.WRITE_COILS:
@@ -127,7 +127,6 @@ def write_analogue(client, reg_start: int, reg_length: int, _unit: int, data_typ
     :return: tuple (val: any, array: list)
     """
     debug_log('write_analogue', _unit, func, reg_length, reg_start)
-    reg_length = _set_data_length(data_type, reg_length)
     byteorder, word_order = _mod_point_data_endian(endian)
     if func == ModbusFunctionCode.WRITE_REGISTER:
         payload = [int(write_value)]

--- a/src/source_drivers/modbus/services/modbus_functions/polling/poll.py
+++ b/src/source_drivers/modbus/services/modbus_functions/polling/poll.py
@@ -36,7 +36,7 @@ def poll_point(service: EventServiceBase, connection, network: ModbusNetworkMode
     point_fc: ModbusFunctionCode = point.function_code
     point_data_type: ModbusDataType = point.data_type
     point_data_endian: ModbusDataEndian = point.data_endian
-    write_value: float = point.write_value
+    write_value: float = point.write_value if point.write_value else 0
 
     logger.debug('--------------- START MODBUS POLL POINT ---------------')
     logger.debug({'network': network,


### PR DESCRIPTION
Resolves: #181 
Resolves: #196 

### Summary:

- Modbus polling crash issue fix
- Restrict `write_value` `null` insertion for write functions