### PR TITLE
Feature/tags

### DIFF
--- a/src/models/model_base.py
+++ b/src/models/model_base.py
@@ -12,6 +12,10 @@ class ModelBase(db.Model):
     updated_on = db.Column(db.DateTime, server_default=db.func.now(), onupdate=db.func.now())
 
     @classmethod
+    def find_all(cls):
+        return cls.query.all()
+
+    @classmethod
     def find_by_uuid(cls, device_uuid):
         return cls.query.filter_by(uuid=device_uuid).first()
 

--- a/src/models/point/model_point.py
+++ b/src/models/point/model_point.py
@@ -35,7 +35,7 @@ class PointModel(ModelBase):
     scale_min = db.Column(db.Float())
     scale_max = db.Column(db.Float())
     point_store = db.relationship('PointStoreModel', backref='point', lazy=False, uselist=False, cascade="all,delete")
-    point_store_history = db.relationship('PointStoreHistoryModel', backref='point')
+    point_store_history = db.relationship('PointStoreHistoryModel', backref='point', lazy=False, cascade="all,delete")
     driver = db.Column(db.String(80))
 
     __mapper_args__ = {

--- a/src/models/point/model_point.py
+++ b/src/models/point/model_point.py
@@ -36,7 +36,7 @@ class PointModel(ModelBase):
     input_max = db.Column(db.Float())
     scale_min = db.Column(db.Float())
     scale_max = db.Column(db.Float())
-    tags = db.Column(db.String(320), nullable=False)
+    tags = db.Column(db.String(320), nullable=True)
     point_store = db.relationship('PointStoreModel', backref='point', lazy=False, uselist=False, cascade="all,delete")
     point_store_history = db.relationship('PointStoreHistoryModel', backref='point', lazy=False, cascade="all,delete")
     driver = db.Column(db.String(80))
@@ -87,7 +87,7 @@ class PointModel(ModelBase):
         - if there is a gap add an underscore
         - no special characters
         """
-        if value:
+        if value is not None:
             try:
                 tags = json.loads(value)
                 return_tags: dict = {}
@@ -99,7 +99,7 @@ class PointModel(ModelBase):
                 return json.dumps(return_tags)
             except ValueError:
                 raise ValueError('tags needs to be a valid JSON')
-        return "{}"
+        return value
 
     @validates('history_interval')
     def validate_history_interval(self, _, value):

--- a/src/resources/rest_schema/schema_point.py
+++ b/src/resources/rest_schema/schema_point.py
@@ -69,6 +69,9 @@ point_all_attributes = {
     'scale_max': {
         'type': float,
     },
+    'tags': {
+        'type': str
+    }
 }
 
 point_return_attributes = {
@@ -83,9 +86,6 @@ point_return_attributes = {
     },
     'updated_on': {
         'type': str,
-    },
-    'writable': {
-        'type': bool,
     },
     'point_store': {
         'type': fields.Nested(point_store_fields),

--- a/src/services/histories/sync/influxdb.py
+++ b/src/services/histories/sync/influxdb.py
@@ -87,10 +87,11 @@ class InfluxDB(HistoryBinding, metaclass=Singleton):
                 tags = plat.copy()
                 point_store_history: PointStoreHistoryModel = psh
                 point: PointModel = point_store_history.point
-                point_tags = json.loads(point.tags)
-                # insert tags from point object
-                for point_tag in point_tags:
-                    tags[point_tag] = point_tags[point_tag]
+                if point.tags:
+                    point_tags = json.loads(point.tags)
+                    # insert tags from point object
+                    for point_tag in point_tags:
+                        tags[point_tag] = point_tags[point_tag]
                 tags.update({
                     'point_uuid': point.uuid,
                     'point_name': point.name,

--- a/src/services/histories/sync/influxdb.py
+++ b/src/services/histories/sync/influxdb.py
@@ -81,35 +81,38 @@ class InfluxDB(HistoryBinding, metaclass=Singleton):
             'site_id': self.__wires_plat.site_id,
             'device_id': self.__wires_plat.device_id
         }
-        for psh in PointStoreHistoryModel.get_all_after(self._get_last_sync_id()):
-            tags = plat.copy()
-            point_store_history: PointStoreHistoryModel = psh
-            point: PointModel = point_store_history.point
-            point_tags = json.loads(point.tags)
-            for point_tag in point_tags:
-                tags[point_tag] = point_tags[point_tag]
-            tags.update({
-                'point_uuid': point.uuid,
-                'point_name': point.name,
-                'device_name': point.device.name,
-                'network_name': point.device.network.name,
-                'driver': point.driver,
-            })
-            fields = {
-                'id': point_store_history.id,
-                'value': point_store_history.value,
-                'value_original': point_store_history.value_original,
-                'value_raw': point_store_history.value_raw,
-                'fault': point_store_history.fault,
-                'fault_message': point_store_history.fault_message,
-            }
-            row = {
-                'measurement': 'history',
-                'tags': tags,
-                'time': point_store_history.ts_value,
-                'fields': fields
-            }
-            store.append(row)
+        for point in PointModel.find_all():
+            point_last_sync_id: int = self._get_point_last_sync_id(point.uuid)
+            for psh in PointStoreHistoryModel.get_all_after(point_last_sync_id):
+                tags = plat.copy()
+                point_store_history: PointStoreHistoryModel = psh
+                point: PointModel = point_store_history.point
+                point_tags = json.loads(point.tags)
+                # insert tags from point object
+                for point_tag in point_tags:
+                    tags[point_tag] = point_tags[point_tag]
+                tags.update({
+                    'point_uuid': point.uuid,
+                    'point_name': point.name,
+                    'device_name': point.device.name,
+                    'network_name': point.device.network.name,
+                    'driver': point.driver,
+                })
+                fields = {
+                    'id': point_store_history.id,
+                    'value': point_store_history.value,
+                    'value_original': point_store_history.value_original,
+                    'value_raw': point_store_history.value_raw,
+                    'fault': point_store_history.fault,
+                    'fault_message': point_store_history.fault_message,
+                }
+                row = {
+                    'measurement': 'history',
+                    'tags': tags,
+                    'time': point_store_history.ts_value,
+                    'fields': fields
+                }
+                store.append(row)
         if len(store):
             logger.debug(f"Storing: {store}")
             self.__client.write_points(store)
@@ -117,8 +120,8 @@ class InfluxDB(HistoryBinding, metaclass=Singleton):
         else:
             logger.debug("Nothing to store, no new records")
 
-    def _get_last_sync_id(self):
-        query = f'SELECT MAX(id) FROM {self.config.measurement}'
+    def _get_point_last_sync_id(self, point_uuid):
+        query = f"SELECT MAX(id), point_uuid FROM {self.config.measurement} WHERE point_uuid='{point_uuid}'"
         result_set = self.__client.query(query)
         points = list(result_set.get_points())
         if len(points) == 0:

--- a/src/services/histories/sync/influxdb.py
+++ b/src/services/histories/sync/influxdb.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import time
 
@@ -84,9 +85,14 @@ class InfluxDB(HistoryBinding, metaclass=Singleton):
             tags = plat.copy()
             point_store_history: PointStoreHistoryModel = psh
             point: PointModel = point_store_history.point
+            point_tags = json.loads(point.tags)
+            for point_tag in point_tags:
+                tags[point_tag] = point_tags[point_tag]
             tags.update({
                 'point_uuid': point.uuid,
-                'name': point.name,
+                'point_name': point.name,
+                'device_name': point.device.name,
+                'network_name': point.device.network.name,
                 'driver': point.driver,
             })
             fields = {


### PR DESCRIPTION
Resolves: #159

### Summary

- Add `tags` on point schema
- Add tags on InfluxDB
- InfluxDB sync improvement

### Example:

See the `Generic > POST: point` on this collection:

https://www.getpostman.com/collections/59b9c3ecf3dd5a350f7b

tags example: 
```
{.., "tags": "{\"test& 1\": \"test\"}"}
```

which will post tag as: `test_1=test`.