### PR TITLE
Fix/polling

### DIFF
--- a/src/drivers/modbus/models/device.py
+++ b/src/drivers/modbus/models/device.py
@@ -14,34 +14,17 @@ class ModbusDeviceModel(DeviceMixinModel):
 
     type = db.Column(db.Enum(ModbusType), nullable=False)
     address = db.Column(db.Integer(), nullable=False)
-    tcp_ip = db.Column(db.String(80))
-    tcp_port = db.Column(db.Integer())
     zero_based = db.Column(db.Boolean(), nullable=False, default=False)
     ping_point = db.Column(db.String(10))
-    timeout = db.Column(db.Integer(), nullable=False, default=3)
-    polling_interval_runtime = db.Column(db.Integer(), default=2)
-    point_interval_ms_between_points = db.Column(db.Integer(), default=30)
     modbus_network_uuid_constraint = db.Column(db.String, nullable=False)
 
     __table_args__ = (
-        UniqueConstraint('tcp_ip', 'address', 'modbus_network_uuid_constraint'),
+        UniqueConstraint('address', 'modbus_network_uuid_constraint'),
     )
 
     @classmethod
     def get_polymorphic_identity(cls) -> Drivers:
         return Drivers.MODBUS
-
-    @validates('tcp_ip')
-    def validate_tcp_ip(self, _, value):
-        if not value and self.type == ModbusType.TCP.name:
-            raise ValueError("tcp_ip should be be there on type TCP")
-        return value
-
-    @validates('tcp_port')
-    def validate_tcp_port(self, _, value):
-        if not value and self.type == ModbusType.TCP.name:
-            raise ValueError("tcp_port should be be there on type TCP")
-        return value
 
     @validates('ping_point')
     def validate_ping_point(self, _, value):

--- a/src/drivers/modbus/models/network.py
+++ b/src/drivers/modbus/models/network.py
@@ -1,3 +1,4 @@
+from sqlalchemy import UniqueConstraint
 from sqlalchemy.orm import validates
 
 from src import db
@@ -8,12 +9,22 @@ from src.models.network.model_network_mixin import NetworkMixinModel
 
 class ModbusNetworkModel(NetworkMixinModel):
     __tablename__ = 'modbus_networks'
-    type = db.Column(db.Enum(ModbusType), nullable=False)
+
     rtu_port = db.Column(db.String(80), nullable=True, unique=True)
     rtu_speed = db.Column(db.Integer(), default=9600)
     rtu_stop_bits = db.Column(db.Integer(), default=1)
     rtu_parity = db.Column(db.Enum(ModbusRtuParity), default=ModbusRtuParity.N)
     rtu_byte_size = db.Column(db.Integer(), default=8)
+    tcp_ip = db.Column(db.String(80))
+    tcp_port = db.Column(db.Integer())
+    type = db.Column(db.Enum(ModbusType), nullable=False)
+    timeout = db.Column(db.Integer(), nullable=False, default=3)
+    polling_interval_runtime = db.Column(db.Integer(), default=2)
+    point_interval_ms_between_points = db.Column(db.Integer(), default=30)
+
+    __table_args__ = (
+        UniqueConstraint('tcp_ip', 'tcp_port'),
+    )
 
     @classmethod
     def get_polymorphic_identity(cls) -> Drivers:
@@ -21,24 +32,15 @@ class ModbusNetworkModel(NetworkMixinModel):
 
     @validates('type')
     def validate_type(self, _, value):
-        if isinstance(value, ModbusType):
-            return value
-        if not value or value not in ModbusType.__members__:
-            raise ValueError("Invalid network type")
-        return ModbusType[value]
-
-    @validates('rtu_port')
-    def validate_rtu_port(self, _, value):
-        if not value and self.type == ModbusType.RTU.name:
-            raise ValueError("rtu_port should be be there on type MTU")
-        return value
-
-    @validates('rtu_byte_size')
-    def validate_rtu_byte_size(self, _, value):
-        msg = "rtu_byte_size The number of bits in a byte of serial data. This can be one of 5, 6, 7, or 8. This " \
-              "defaults to 8"
-        if value not in range(5, 9):
-            raise ValueError(msg)
-        elif not value:
-            raise ValueError(msg)
+        if value == ModbusType.RTU.name:
+            if not self.rtu_port:
+                raise ValueError("rtu_port should be be there on type RTU")
+            if not self.rtu_byte_size or self.rtu_byte_size not in range(5, 9):
+                raise ValueError("rtu_byte_size The number of bits in a byte of serial data. This can be one of 5, 6, "
+                                 "7, or 8. This defaults to 8")
+        elif value == ModbusType.TCP.name:
+            if not self.tcp_ip:
+                raise ValueError("tcp_ip should be be there on type TCP")
+            if not self.tcp_port:
+                raise ValueError("tcp_port should be be there on type TCP")
         return value

--- a/src/drivers/modbus/resources/rest_schema/schema_modbus_device.py
+++ b/src/drivers/modbus/resources/rest_schema/schema_modbus_device.py
@@ -6,26 +6,11 @@ modbus_device_all_attributes['address'] = {
     'type': int,
     'required': True,
 }
-modbus_device_all_attributes['tcp_ip'] = {
-    'type': str,
-}
-modbus_device_all_attributes['tcp_port'] = {
-    'type': int,
-}
 modbus_device_all_attributes['zero_based'] = {
     'type': bool,
 }
 modbus_device_all_attributes['ping_point'] = {
     'type': str,
-}
-modbus_device_all_attributes['timeout'] = {
-    'type': int,
-}
-modbus_device_all_attributes['polling_interval_runtime'] = {
-    'type': int,
-}
-modbus_device_all_attributes['point_interval_ms_between_points'] = {
-    'type': int,
 }
 
 modbus_device_return_attributes = deepcopy(device_return_attributes)

--- a/src/drivers/modbus/resources/rest_schema/schema_modbus_network.py
+++ b/src/drivers/modbus/resources/rest_schema/schema_modbus_network.py
@@ -3,12 +3,6 @@ from src.drivers.modbus.resources.rest_schema.schema_modbus_device import modbus
 from src.resources.rest_schema.schema_network import *
 
 modbus_network_all_attributes = deepcopy(network_all_attributes)
-modbus_network_all_attributes['type'] = {
-    'type': str,
-    'required': True,
-    'nested': True,
-    'dict': 'type.name'
-}
 modbus_network_all_attributes['rtu_port'] = {
     'type': str,
 }
@@ -24,6 +18,27 @@ modbus_network_all_attributes['rtu_parity'] = {
     'dict': 'rtu_parity.name'
 }
 modbus_network_all_attributes['rtu_byte_size'] = {
+    'type': int,
+}
+modbus_network_all_attributes['tcp_ip'] = {
+    'type': str,
+}
+modbus_network_all_attributes['tcp_port'] = {
+    'type': int,
+}
+modbus_network_all_attributes['type'] = {
+    'type': str,
+    'required': True,
+    'nested': True,
+    'dict': 'type.name'
+}
+modbus_network_all_attributes['timeout'] = {
+    'type': int,
+}
+modbus_network_all_attributes['polling_interval_runtime'] = {
+    'type': int,
+}
+modbus_network_all_attributes['point_interval_ms_between_points'] = {
     'type': int,
 }
 

--- a/src/drivers/modbus/services/modbus_tcp_registry.py
+++ b/src/drivers/modbus/services/modbus_tcp_registry.py
@@ -2,7 +2,6 @@ import logging
 
 from pymodbus.client.sync import ModbusTcpClient
 
-from src.drivers.modbus.models.device import ModbusDeviceModel
 from src.drivers.modbus.models.network import ModbusNetworkModel, ModbusType
 from src.drivers.modbus.services.modbus_registry import ModbusRegistryKey, ModbusRegistry, \
     ModbusRegistryConnection
@@ -12,16 +11,16 @@ logger = logging.getLogger(__name__)
 
 class ModbusTcpRegistryKey(ModbusRegistryKey):
     def create_connection_key(self) -> str:
-        return f'{self.device.tcp_ip}:{self.device.tcp_port}:{self.device.timeout}'
+        return f'{self.network.tcp_ip}:{self.network.tcp_port}:{self.network.timeout}'
 
 
 class ModbusTcpRegistry(ModbusRegistry):
 
-    def add_connection(self, network: ModbusNetworkModel, device: ModbusDeviceModel) -> ModbusRegistryConnection:
-        host: str = device.tcp_ip
-        port: int = device.tcp_port
-        timeout: int = device.timeout
-        registry_key: ModbusTcpRegistryKey = ModbusTcpRegistryKey(network, device)
+    def add_connection(self, network: ModbusNetworkModel) -> ModbusRegistryConnection:
+        host: str = network.tcp_ip
+        port: int = network.tcp_port
+        timeout: int = network.timeout
+        registry_key: ModbusTcpRegistryKey = ModbusTcpRegistryKey(network)
         self.remove_connection_if_exist(registry_key.key)
         logger.debug(f'Adding tcp_connection {registry_key.key}')
         self.connections[registry_key.key] = ModbusRegistryConnection(
@@ -30,8 +29,8 @@ class ModbusTcpRegistry(ModbusRegistry):
         )
         return self.connections[registry_key.key]
 
-    def get_registry_key(self, network: ModbusNetworkModel, device: ModbusDeviceModel) -> ModbusRegistryKey:
-        return ModbusTcpRegistryKey(network, device)
+    def get_registry_key(self, network: ModbusNetworkModel) -> ModbusRegistryKey:
+        return ModbusTcpRegistryKey(network)
 
     def get_type(self) -> ModbusType:
         return ModbusType.TCP


### PR DESCRIPTION
### Summary

- Change Modbus schema for Network and Device **(Frontend also needs to be changed)**
   - `tcp_ip`, `tcp_port`, `type`, `timeout`, `polling_interval_runtime`, `point_interval_ms_between_points` are transferred from `Device` to `Network` model
- Created connection from `Network` instead of `Network <> Device` connection (each connection has different threads)