### PR TITLE
Feature/two way binding gp mp

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -43,15 +43,15 @@ def create_app(app_setting) -> Flask:
         cursor.close()
 
     def register_router(_app) -> Flask:
-        from src.routes import bp_network, bp_device, bp_point, bp_generic, bp_modbus, bp_mapping_mp_gbp, \
-            bp_sync_mp_bp, bp_system, bp_schedule
+        from src.routes import bp_network, bp_device, bp_point, bp_generic, bp_modbus, bp_mapping_mp_gbp, bp_sync, \
+            bp_system, bp_schedule
         _app.register_blueprint(bp_network)
         _app.register_blueprint(bp_device)
         _app.register_blueprint(bp_point)
         _app.register_blueprint(bp_generic)
         _app.register_blueprint(bp_modbus)
         _app.register_blueprint(bp_mapping_mp_gbp)
-        _app.register_blueprint(bp_sync_mp_bp)
+        _app.register_blueprint(bp_sync)
         _app.register_blueprint(bp_system)
         _app.register_blueprint(bp_schedule)
         return _app

--- a/src/app.py
+++ b/src/app.py
@@ -43,14 +43,15 @@ def create_app(app_setting) -> Flask:
         cursor.close()
 
     def register_router(_app) -> Flask:
-        from src.routes import bp_network, bp_device, bp_point, bp_generic, bp_modbus, bp_mapping_mp_gbp, bp_system, \
-            bp_schedule
+        from src.routes import bp_network, bp_device, bp_point, bp_generic, bp_modbus, bp_mapping_mp_gbp, \
+            bp_sync_mp_bp, bp_system, bp_schedule
         _app.register_blueprint(bp_network)
         _app.register_blueprint(bp_device)
         _app.register_blueprint(bp_point)
         _app.register_blueprint(bp_generic)
         _app.register_blueprint(bp_modbus)
         _app.register_blueprint(bp_mapping_mp_gbp)
+        _app.register_blueprint(bp_sync_mp_bp)
         _app.register_blueprint(bp_system)
         _app.register_blueprint(bp_schedule)
         return _app

--- a/src/background.py
+++ b/src/background.py
@@ -93,11 +93,11 @@ class Background:
         from .models.point.model_point_store import PointStoreModel
 
         """Sync mapped points values from LoRa > Generic points values"""
-        FlaskThread(target=api_to_topic_mapper, kwargs={'api': "/api/sync/lp_gp", 'destination_identifier': 'lora',
+        FlaskThread(target=api_to_topic_mapper, kwargs={'api': "/api/sync/lp_to_gp", 'destination_identifier': 'lora',
                                                         'http_method': HttpMethod.GET}).start()
 
         """Sync mapped points values from BACnet > Generic points values"""
-        FlaskThread(target=api_to_topic_mapper, kwargs={'api': "/api/sync/bp_gp", 'destination_identifier': 'bacnet',
+        FlaskThread(target=api_to_topic_mapper, kwargs={'api': "/api/sync/bp_to_gp", 'destination_identifier': 'bacnet',
                                                         'http_method': HttpMethod.GET}).start()
         """Sync mapped points values from Modbus > Generic | BACnet points values"""
         PointStoreModel.sync_points_values_mp_to_gbp_process()

--- a/src/background.py
+++ b/src/background.py
@@ -92,21 +92,12 @@ class Background:
         from mrb.message import HttpMethod
         from .models.point.model_point_store import PointStoreModel
 
-        """
-        Sync mapped points values from LoRa > Generic points values
-        Because: LoRa Points > Generic Points
-        """
+        """Sync mapped points values from LoRa > Generic points values"""
         FlaskThread(target=api_to_topic_mapper, kwargs={'api': "/api/sync/lp_gp", 'destination_identifier': 'lora',
                                                         'http_method': HttpMethod.GET}).start()
 
-        """
-        Sync mapped points values from BACnet > Generic points values
-        Because: BACnet Points <> Generic Points
-        """
+        """Sync mapped points values from BACnet > Generic points values"""
         FlaskThread(target=api_to_topic_mapper, kwargs={'api': "/api/sync/bp_gp", 'destination_identifier': 'bacnet',
                                                         'http_method': HttpMethod.GET}).start()
-        """
-        Sync mapped points values from Modbus > Generic | BACnet points values
-        Because: Modbus Points <> Generic | BACnet Points 
-        """
-        FlaskThread(target=PointStoreModel.sync_points_values_mp_gbp).start()
+        """Sync mapped points values from Modbus > Generic | BACnet points values"""
+        PointStoreModel.sync_points_values_mp_to_gbp_process()

--- a/src/background.py
+++ b/src/background.py
@@ -100,4 +100,4 @@ class Background:
         FlaskThread(target=api_to_topic_mapper, kwargs={'api': "/api/sync/bp_to_gp", 'destination_identifier': 'bacnet',
                                                         'http_method': HttpMethod.GET}).start()
         """Sync mapped points values from Modbus > Generic | BACnet points values"""
-        PointStoreModel.sync_points_values_mp_to_gbp_process()
+        PointStoreModel.sync_points_values_mp_to_gbp_process(force_sync=True)

--- a/src/background.py
+++ b/src/background.py
@@ -92,12 +92,21 @@ class Background:
         from mrb.message import HttpMethod
         from .models.point.model_point_store import PointStoreModel
 
-        """Sync mapped points values from LoRa > Generic points values"""
+        """
+        Sync mapped points values from LoRa > Generic points values
+        Because: LoRa Points > Generic Points
+        """
         FlaskThread(target=api_to_topic_mapper, kwargs={'api': "/api/sync/lp_gp", 'destination_identifier': 'lora',
                                                         'http_method': HttpMethod.GET}).start()
 
-        """Sync mapped points values from BACnet > Generic points values"""
+        """
+        Sync mapped points values from BACnet > Generic points values
+        Because: BACnet Points <> Generic Points
+        """
         FlaskThread(target=api_to_topic_mapper, kwargs={'api': "/api/sync/bp_gp", 'destination_identifier': 'bacnet',
                                                         'http_method': HttpMethod.GET}).start()
-        """Sync mapped points values from Modbus > Generic | BACnet points values """
+        """
+        Sync mapped points values from Modbus > Generic | BACnet points values
+        Because: Modbus Points <> Generic | BACnet Points 
+        """
         FlaskThread(target=PointStoreModel.sync_points_values_mp_gbp).start()

--- a/src/drivers/generic/models/point.py
+++ b/src/drivers/generic/models/point.py
@@ -7,8 +7,6 @@ from src.models.point.model_point_mixin import PointMixinModel
 class GenericPointModel(PointMixinModel):
     __tablename__ = 'generic_points'
 
-    priority_array_write = db.relationship('PriorityArrayModel', backref='generic_points', lazy=False, uselist=False,
-                                           cascade="all,delete")
     type = db.Column(db.Enum(GenericPointType), nullable=False, default=GenericPointType.FLOAT)
     unit = db.Column(db.String, nullable=True)
 

--- a/src/drivers/generic/resources/point/point_base.py
+++ b/src/drivers/generic/resources/point/point_base.py
@@ -4,7 +4,8 @@ from flask_restful import reqparse
 from rubix_http.resource import RubixResource
 
 from src.drivers.generic.models.point import GenericPointModel
-from src.drivers.generic.resources.rest_schema.schema_generic_point import generic_point_all_attributes
+from src.drivers.generic.resources.rest_schema.schema_generic_point import generic_point_all_attributes, \
+    add_nested_priority_array_write
 from src.models.point.priority_array import PriorityArrayModel
 from src.services.points_registry import PointsRegistry
 
@@ -17,12 +18,17 @@ class GenericPointBase(RubixResource):
                             required=generic_point_all_attributes[attr].get('required', False),
                             help=generic_point_all_attributes[attr].get('help', None),
                             store_missing=False)
+    add_nested_priority_array_write()
 
     @classmethod
     def add_point(cls, data):
         _uuid: str = str(uuid.uuid4())
-        point: GenericPointModel = GenericPointModel(uuid=_uuid, **data)
-        point.priority_array_write = PriorityArrayModel.create_new_priority_array_model(_uuid)
+        priority_array_write: dict = data.pop('priority_array_write', {})
+        point = GenericPointModel(
+            uuid=_uuid,
+            priority_array_write=PriorityArrayModel.create_priority_array_model(_uuid, priority_array_write),
+            **data
+        )
         point.save_to_db()
         PointsRegistry().add_point(point)
         return point

--- a/src/drivers/generic/resources/point/point_base.py
+++ b/src/drivers/generic/resources/point/point_base.py
@@ -4,8 +4,8 @@ from flask_restful import reqparse
 from rubix_http.resource import RubixResource
 
 from src.drivers.generic.models.point import GenericPointModel
-from src.drivers.generic.models.priority_array import PriorityArrayModel
 from src.drivers.generic.resources.rest_schema.schema_generic_point import generic_point_all_attributes
+from src.models.point.priority_array import PriorityArrayModel
 from src.services.points_registry import PointsRegistry
 
 

--- a/src/drivers/generic/resources/point/point_value_writer.py
+++ b/src/drivers/generic/resources/point/point_value_writer.py
@@ -1,8 +1,6 @@
 from abc import abstractmethod
 
 from flask_restful import reqparse
-from flask_restful.reqparse import request
-from mrb.validator import is_bridge
 from rubix_http.exceptions.exception import NotFoundException, BadDataException
 from rubix_http.resource import RubixResource
 
@@ -34,8 +32,7 @@ class GenericPointValueWriterBase(RubixResource):
                                  priority=data.get('priority'),
                                  value_raw=data.get('value_raw'),
                                  fault=data.get('fault'),
-                                 fault_message=data.get('fault_message'),
-                                 sync=not is_bridge(request.args))
+                                 fault_message=data.get('fault_message'))
         return {}
 
 

--- a/src/drivers/generic/resources/point/point_value_writer.py
+++ b/src/drivers/generic/resources/point/point_value_writer.py
@@ -6,10 +6,10 @@ from mrb.validator import is_bridge
 from rubix_http.exceptions.exception import NotFoundException, BadDataException
 from rubix_http.resource import RubixResource
 
-from src.models.point.model_point import PointModel
+from src.drivers.generic.models.point import GenericPointModel
 
 
-class PointValueWriterBase(RubixResource):
+class GenericPointValueWriterBase(RubixResource):
     patch_parser = reqparse.RequestParser()
     patch_parser.add_argument('value', type=float, required=False)
     patch_parser.add_argument('value_raw', type=str, required=False)
@@ -19,13 +19,13 @@ class PointValueWriterBase(RubixResource):
 
     @classmethod
     @abstractmethod
-    def get_point(cls, **kwargs) -> PointModel:
+    def get_point(cls, **kwargs) -> GenericPointModel:
         raise NotImplementedError('Please override get_point method')
 
     @classmethod
     def patch(cls, **kwargs):
-        data = PointValueWriterBase.patch_parser.parse_args()
-        point: PointModel = cls.get_point(**kwargs)
+        data = cls.patch_parser.parse_args()
+        point: GenericPointModel = cls.get_point(**kwargs)
         if not point:
             raise NotFoundException('Point does not exist')
         if not point.writable:
@@ -39,13 +39,14 @@ class PointValueWriterBase(RubixResource):
         return {}
 
 
-class PointUUIDValueWriter(PointValueWriterBase):
+class GenericPointUUIDValueWriter(GenericPointValueWriterBase):
     @classmethod
-    def get_point(cls, **kwargs) -> PointModel:
-        return PointModel.find_by_uuid(kwargs.get('uuid'))
+    def get_point(cls, **kwargs) -> GenericPointModel:
+        return GenericPointModel.find_by_uuid(kwargs.get('uuid'))
 
 
-class PointNameValueWriter(PointValueWriterBase):
+class GenericPointNameValueWriter(GenericPointValueWriterBase):
     @classmethod
-    def get_point(cls, **kwargs) -> PointModel:
-        return PointModel.find_by_name(kwargs.get('network_name'), kwargs.get('device_name'), kwargs.get('point_name'))
+    def get_point(cls, **kwargs) -> GenericPointModel:
+        return GenericPointModel.find_by_name(kwargs.get('network_name'), kwargs.get('device_name'),
+                                              kwargs.get('point_name'))

--- a/src/drivers/generic/resources/rest_schema/schema_generic_point.py
+++ b/src/drivers/generic/resources/rest_schema/schema_generic_point.py
@@ -1,26 +1,6 @@
-from collections import OrderedDict
 from copy import deepcopy
 
 from src.resources.rest_schema.schema_point import *
-
-priority_array_write_fields = OrderedDict({
-    '_1': fields.Float,
-    '_2': fields.Float,
-    '_3': fields.Float,
-    '_4': fields.Float,
-    '_5': fields.Float,
-    '_6': fields.Float,
-    '_7': fields.Float,
-    '_8': fields.Float,
-    '_9': fields.Float,
-    '_10': fields.Float,
-    '_11': fields.Float,
-    '_12': fields.Float,
-    '_13': fields.Float,
-    '_14': fields.Float,
-    '_15': fields.Float,
-    '_16': fields.Float,
-})
 
 generic_point_all_attributes = deepcopy(point_all_attributes)
 generic_point_all_attributes['type'] = {
@@ -33,9 +13,6 @@ generic_point_all_attributes['unit'] = {
 }
 
 generic_point_return_attributes = deepcopy(point_return_attributes)
-generic_point_return_attributes['priority_array_write'] = {
-    'type': fields.Nested(priority_array_write_fields),
-}
 generic_point_all_fields = {}
 map_rest_schema(generic_point_return_attributes, generic_point_all_fields)
 map_rest_schema(generic_point_all_attributes, generic_point_all_fields)

--- a/src/drivers/generic/resources/rest_schema/schema_generic_point.py
+++ b/src/drivers/generic/resources/rest_schema/schema_generic_point.py
@@ -14,5 +14,5 @@ generic_point_all_attributes['unit'] = {
 
 generic_point_return_attributes = deepcopy(point_return_attributes)
 generic_point_all_fields = {}
-map_rest_schema(generic_point_return_attributes, generic_point_all_fields)
 map_rest_schema(generic_point_all_attributes, generic_point_all_fields)
+map_rest_schema(generic_point_return_attributes, generic_point_all_fields)

--- a/src/drivers/modbus/models/device.py
+++ b/src/drivers/modbus/models/device.py
@@ -1,3 +1,4 @@
+from rubix_http.exceptions.exception import NotFoundException
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.orm import validates
 
@@ -41,7 +42,7 @@ class ModbusDeviceModel(DeviceMixinModel):
         network = NetworkModel.find_by_uuid(self.network_uuid)
         # can't get sqlalchemy column default to do this so this is solution
         if network is None:
-            raise Exception(f'No network found with uuid {self.network_uuid}')
+            raise NotFoundException(f'No network found with uuid {self.network_uuid}')
         self.type = network.type
         self.modbus_network_uuid_constraint = self.network_uuid
         return True

--- a/src/drivers/modbus/models/mapping.py
+++ b/src/drivers/modbus/models/mapping.py
@@ -3,7 +3,9 @@ from mrb.message import Response, HttpMethod
 from sqlalchemy.orm import validates
 
 from src import db
+from src.enums.model import ModelEvent
 from src.models.model_base import ModelBase
+from src.services.event_service_base import EventType
 
 
 class MPGBPMapping(ModelBase):
@@ -19,6 +21,12 @@ class MPGBPMapping(ModelBase):
     modbus_point_name = db.Column(db.String(80), nullable=False)
     generic_point_name = db.Column(db.String(80), nullable=True)
     bacnet_point_name = db.Column(db.String(80), nullable=True)
+
+    def get_model_event(self) -> ModelEvent:
+        return ModelEvent.MAPPING
+
+    def get_model_event_type(self) -> EventType:
+        return EventType.MAPPING_MODEL
 
     @validates('generic_point_uuid')
     def validate_generic_point_uuid(self, _, value):

--- a/src/drivers/modbus/resources/mapping/mapping.py
+++ b/src/drivers/modbus/resources/mapping/mapping.py
@@ -13,7 +13,7 @@ from src.models.point.model_point_store import PointStoreModel
 
 def sync_point_value(mapping: MPGBPMapping):
     point_store: PointStoreModel = PointStoreModel.find_by_point_uuid(mapping.modbus_point_uuid)
-    point_store.sync_point_value_with_mapping_mp_gbp(mapping)
+    point_store.sync_point_value_with_mapping_mp_to_gbp(mapping.generic_point_uuid, mapping.bacnet_point_uuid)
     return mapping
 
 

--- a/src/drivers/modbus/resources/point/point_base.py
+++ b/src/drivers/modbus/resources/point/point_base.py
@@ -5,6 +5,7 @@ from rubix_http.resource import RubixResource
 
 from src.drivers.modbus.models.point import ModbusPointModel
 from src.drivers.modbus.resources.rest_schema.schema_modbus_point import modbus_point_all_attributes
+from src.models.point.priority_array import PriorityArrayModel
 
 
 class ModbusPointBase(RubixResource):
@@ -20,5 +21,6 @@ class ModbusPointBase(RubixResource):
     def add_point(cls, data):
         _uuid = str(uuid.uuid4())
         point = ModbusPointModel(uuid=_uuid, **data)
+        point.priority_array_write = PriorityArrayModel.create_new_priority_array_model(_uuid)
         point.save_to_db()
         return point

--- a/src/drivers/modbus/resources/point/point_base.py
+++ b/src/drivers/modbus/resources/point/point_base.py
@@ -4,7 +4,8 @@ from flask_restful import reqparse
 from rubix_http.resource import RubixResource
 
 from src.drivers.modbus.models.point import ModbusPointModel
-from src.drivers.modbus.resources.rest_schema.schema_modbus_point import modbus_point_all_attributes
+from src.drivers.modbus.resources.rest_schema.schema_modbus_point import modbus_point_all_attributes, \
+    add_nested_priority_array_write
 from src.models.point.priority_array import PriorityArrayModel
 
 
@@ -16,11 +17,16 @@ class ModbusPointBase(RubixResource):
                             required=modbus_point_all_attributes[attr].get('required', False),
                             help=modbus_point_all_attributes[attr].get('help', None),
                             store_missing=False)
+    add_nested_priority_array_write()
 
     @classmethod
     def add_point(cls, data):
         _uuid = str(uuid.uuid4())
-        point = ModbusPointModel(uuid=_uuid, **data)
-        point.priority_array_write = PriorityArrayModel.create_new_priority_array_model(_uuid)
+        priority_array_write: dict = data.pop('priority_array_write', {})
+        point = ModbusPointModel(
+            uuid=_uuid,
+            priority_array_write=PriorityArrayModel.create_priority_array_model(_uuid, priority_array_write),
+            **data
+        )
         point.save_to_db()
         return point

--- a/src/drivers/modbus/resources/point/point_poll.py
+++ b/src/drivers/modbus/resources/point/point_poll.py
@@ -10,6 +10,7 @@ from src.drivers.modbus.resources.rest_schema.schema_modbus_point import modbus_
     point_store_fields, modbus_point_all_fields
 from src.drivers.modbus.services.polling.modbus_polling import ModbusPolling
 from src.event_dispatcher import EventDispatcher
+from src.models.point.priority_array import PriorityArrayModel
 from src.services.event_service_base import EventCallableBlocking
 
 
@@ -48,7 +49,10 @@ class ModbusPointPollNonExisting(RubixResource):
 
         network = ModbusNetworkModel.create_temporary(**network_data)
         device = ModbusDeviceModel.create_temporary(**device_data)
-        point = ModbusPointModel.create_temporary(**point_data)
+        priority_array_write: dict = point_data.pop('priority_array_write', {})
+        point = ModbusPointModel.create_temporary(
+            priority_array_write=PriorityArrayModel.create_priority_array_model(None, priority_array_write),
+            **point_data)
         network.check_self()
         device.check_self()
         point.check_self()

--- a/src/drivers/modbus/resources/point/point_sync.py
+++ b/src/drivers/modbus/resources/point/point_sync.py
@@ -1,0 +1,10 @@
+from rubix_http.resource import RubixResource
+
+from src.models.point.model_point_store import PointStoreModel
+
+
+class MPBPSync(RubixResource):
+
+    @classmethod
+    def get(cls):
+        PointStoreModel.sync_points_values_mp_to_gbp_process(gp=False)

--- a/src/drivers/modbus/resources/point/point_sync.py
+++ b/src/drivers/modbus/resources/point/point_sync.py
@@ -3,7 +3,7 @@ from rubix_http.resource import RubixResource
 from src.models.point.model_point_store import PointStoreModel
 
 
-class MPBPSync(RubixResource):
+class MPToBPSync(RubixResource):
 
     @classmethod
     def get(cls):

--- a/src/drivers/modbus/resources/point/point_value_writer.py
+++ b/src/drivers/modbus/resources/point/point_value_writer.py
@@ -1,0 +1,40 @@
+from abc import abstractmethod
+
+from flask_restful import reqparse
+from rubix_http.resource import RubixResource
+
+from src.drivers.modbus.models.point import ModbusPointModel
+
+
+class ModbusPointValueWriterBase(RubixResource):
+    patch_parser = reqparse.RequestParser()
+    patch_parser.add_argument('value', type=float, required=False)
+    patch_parser.add_argument('value_raw', type=str, required=False)
+    patch_parser.add_argument('priority', type=int, required=False)
+
+    @classmethod
+    @abstractmethod
+    def get_point(cls, **kwargs) -> ModbusPointModel:
+        raise NotImplementedError('Please override get_point method')
+
+    @classmethod
+    def patch(cls, **kwargs):
+        data = cls.patch_parser.parse_args()
+        point: ModbusPointModel = cls.get_point(**kwargs)
+        point.update_priority_value(value=data.get('value'),
+                                    priority=data.get('priority'),
+                                    value_raw=data.get('value_raw'))
+        return {}
+
+
+class ModbusPointUUIDValueWriter(ModbusPointValueWriterBase):
+    @classmethod
+    def get_point(cls, **kwargs) -> ModbusPointModel:
+        return ModbusPointModel.find_by_uuid(kwargs.get('uuid'))
+
+
+class ModbusPointNameValueWriter(ModbusPointValueWriterBase):
+    @classmethod
+    def get_point(cls, **kwargs) -> ModbusPointModel:
+        return ModbusPointModel.find_by_name(kwargs.get('network_name'), kwargs.get('device_name'),
+                                             kwargs.get('point_name'))

--- a/src/drivers/modbus/resources/rest_schema/schema_modbus_point.py
+++ b/src/drivers/modbus/resources/rest_schema/schema_modbus_point.py
@@ -76,8 +76,8 @@ modbus_poll_non_existing_attributes = {
         'type': str,
         'required': True
     },
-    'point_write_value': {
-        'type': float,
+    'point_priority_array_write': {
+        'type': dict,
     },
     'point_data_type': {
         'type': str,
@@ -90,5 +90,5 @@ modbus_poll_non_existing_attributes = {
 modbus_point_return_attributes = deepcopy(point_return_attributes)
 
 modbus_point_all_fields = {}
-map_rest_schema(modbus_point_return_attributes, modbus_point_all_fields)
 map_rest_schema(modbus_point_all_attributes, modbus_point_all_fields)
+map_rest_schema(modbus_point_return_attributes, modbus_point_all_fields)

--- a/src/drivers/modbus/services/polling/modbus_polling.py
+++ b/src/drivers/modbus/services/polling/modbus_polling.py
@@ -117,7 +117,7 @@ class ModbusPolling(EventServiceBase):
                 """
                 group and sort points into corresponding FCs
                 """
-                fc_lists: List[List[PointStoreModel]] = [[], [], [], [], [], []]
+                fc_lists: List[List[ModbusPointModel]] = [[], [], [], [], [], []]
 
                 for point in points:
                     if point.function_code is ModbusFunctionCode.READ_COILS:

--- a/src/drivers/modbus/services/polling/poll.py
+++ b/src/drivers/modbus/services/polling/poll.py
@@ -144,7 +144,7 @@ def poll_point(service: EventServiceBase, client: BaseModbusClient, network: Mod
 
     if update:
         try:
-            is_updated = point.update_point_value(point_store_new)
+            is_updated = point.update_point_value(point_store_new, point.driver)
         except BaseException as e:
             logger.error(e)
             return point_store_new

--- a/src/drivers/modbus/services/polling/poll.py
+++ b/src/drivers/modbus/services/polling/poll.py
@@ -14,6 +14,7 @@ from src.drivers.modbus.services.polling.functions import read_digital, write_di
 from src.drivers.modbus.services.polling.function_utils import _mod_point_data_endian, convert_to_data_type, \
     pack_point_write_registers
 from src.models.point.model_point_store import PointStoreModel
+from src.models.point.priority_array import PriorityArrayModel
 from src.services.event_service_base import EventServiceBase
 
 logger = logging.getLogger(__name__)
@@ -113,7 +114,7 @@ def poll_point(service: EventServiceBase, client: BaseModbusClient, network: Mod
     point_fc: ModbusFunctionCode = point.function_code
     point_data_type: ModbusDataType = point.data_type
     point_data_endian: ModbusDataEndian = point.data_endian
-    write_value: float = point.write_value if point.write_value else 0
+    write_value: float = PriorityArrayModel.get_highest_priority_value_from_dict(point.priority_array_write) or 0
 
     fault: bool = False
     fault_message: str = ""

--- a/src/enums/model.py
+++ b/src/enums/model.py
@@ -6,3 +6,4 @@ class ModelEvent(enum.Enum):
     DEVICE = 1
     NETWORK = 2
     SCHEDULE = 3
+    MAPPING = 4

--- a/src/models/model_base.py
+++ b/src/models/model_base.py
@@ -90,10 +90,10 @@ class ModelBase(db.Model):
         return {c.key: str(getattr(self, c.key))
                 for c in inspect(self).mapper.column_attrs}
 
-    def _dispatch_event(self, payload: dict = {}):
+    def _dispatch_event(self, payload: dict = None):
         # TODO: better use of dispatching
         event = Event(self.get_model_event_type(), {
             'model': self,
-            'payload': payload
+            'payload': payload or {}
         })
         EventDispatcher().dispatch_from_service(None, event, None)

--- a/src/models/point/model_point.py
+++ b/src/models/point/model_point.py
@@ -8,7 +8,6 @@ from sqlalchemy.orm import validates
 from src import db
 from src.drivers.enums.drivers import Drivers
 from src.drivers.generic.enums.point.points import GenericPointType
-from src.drivers.generic.models.priority_array import PriorityArrayModel
 from src.enums.model import ModelEvent
 from src.enums.point import HistoryType, MathOperation
 from src.models.device.model_device import DeviceModel
@@ -16,6 +15,7 @@ from src.models.model_base import ModelBase
 from src.models.network.model_network import NetworkModel
 from src.models.point.model_point_store import PointStoreModel
 from src.models.point.model_point_store_history import PointStoreHistoryModel
+from src.models.point.priority_array import PriorityArrayModel
 from src.services.event_service_base import Event, EventType
 
 logger = logging.getLogger(__name__)
@@ -31,7 +31,11 @@ class PointModel(ModelBase):
     history_type = db.Column(db.Enum(HistoryType), nullable=False, default=HistoryType.INTERVAL)
     history_interval = db.Column(db.Integer, nullable=False, default=15)
     writable = db.Column(db.Boolean, nullable=False, default=False)
-    write_value = db.Column(db.Float, nullable=True, default=None)  # TODO: more data types...
+    priority_array_write = db.relationship('PriorityArrayModel',
+                                           backref='points',
+                                           lazy=False,
+                                           uselist=False,
+                                           cascade="all,delete")
     cov_threshold = db.Column(db.Float, nullable=False, default=0)
     value_round = db.Column(db.Integer(), nullable=False, default=2)
     value_offset = db.Column(db.Float(), nullable=False, default=0)

--- a/src/models/point/model_point.py
+++ b/src/models/point/model_point.py
@@ -79,8 +79,7 @@ class PointModel(ModelBase):
         self.point_store = PointStoreModel.create_new_point_store_model(self.uuid)
         super().save_to_db()
 
-    def update_point_value(self, point_store: PointStoreModel, driver: Drivers, cov_threshold: float = None,
-                           sync: bool = True) -> bool:
+    def update_point_value(self, point_store: PointStoreModel, driver: Drivers, cov_threshold: float = None) -> bool:
         if not point_store.fault:
             if cov_threshold is None:
                 cov_threshold = self.cov_threshold
@@ -92,7 +91,7 @@ class PointModel(ModelBase):
                 value = self.apply_offset(value, self.value_offset, self.value_operation)
                 value = round(value, self.value_round)
             point_store.value = self.apply_point_type(value)
-        return point_store.update(driver, cov_threshold, sync)
+        return point_store.update(driver, cov_threshold)
 
     @validates('tags')
     def validate_tags(self, _, value):
@@ -140,8 +139,7 @@ class PointModel(ModelBase):
 
         return self
 
-    def update_point_store(self, value: float, priority: int, value_raw: str, fault: bool, fault_message: str,
-                           sync: bool = True):
+    def update_point_store(self, value: float, priority: int, value_raw: str, fault: bool, fault_message: str):
         self.update_priority_value(priority, value, value_raw)
         highest_priority_value = PriorityArrayModel.get_highest_priority_value(self.uuid)
         point_store = PointStoreModel(point_uuid=self.uuid,
@@ -149,7 +147,7 @@ class PointModel(ModelBase):
                                       value_raw=value_raw if value_raw is not None else highest_priority_value,
                                       fault=fault,
                                       fault_message=fault_message)
-        updated = self.update_point_value(point_store, self.driver, sync=sync)
+        updated = self.update_point_value(point_store, self.driver)
         if updated:
             self.publish_cov(point_store)
         db.session.commit()

--- a/src/models/point/model_point.py
+++ b/src/models/point/model_point.py
@@ -142,15 +142,7 @@ class PointModel(ModelBase):
 
     def update_point_store(self, value: float, priority: int, value_raw: str, fault: bool, fault_message: str,
                            sync: bool = True):
-        if not priority:
-            priority = 16
-        if priority not in range(1, 17):
-            raise ValueError('priority should be in range(1, 17)')
-        if value_raw is not None and value is not None:
-            raise ValueError('Invalid, cannot pass both value_raw and value')
-        if priority:
-            PriorityArrayModel.filter_by_point_uuid(self.uuid).update({f"_{priority}": value})
-            db.session.commit()
+        self.update_priority_value(priority, value, value_raw)
         highest_priority_value = PriorityArrayModel.get_highest_priority_value(self.uuid)
         point_store = PointStoreModel(point_uuid=self.uuid,
                                       value_original=highest_priority_value,
@@ -161,6 +153,17 @@ class PointModel(ModelBase):
         if updated:
             self.publish_cov(point_store)
         db.session.commit()
+
+    def update_priority_value(self, priority, value, value_raw):
+        if not priority:
+            priority = 16
+        if priority not in range(1, 17):
+            raise ValueError('priority should be in range(1, 17)')
+        if value_raw is not None and value is not None:
+            raise ValueError('Invalid, cannot pass both value_raw and value')
+        if priority:
+            PriorityArrayModel.filter_by_point_uuid(self.uuid).update({f"_{priority}": value})
+            db.session.commit()
 
     @classmethod
     def apply_offset(cls, original_value: float, value_offset: float, value_operation: MathOperation) -> float or None:

--- a/src/models/point/model_point_store.py
+++ b/src/models/point/model_point_store.py
@@ -1,12 +1,13 @@
 from ast import literal_eval
 from typing import List
 
+import gevent
 from mrb.brige import MqttRestBridge
 from mrb.mapper import api_to_topic_mapper
 from mrb.message import HttpMethod, Response
 from sqlalchemy import and_, or_
 
-from src import db, FlaskThread
+from src import db
 from src.drivers.enums.drivers import Drivers
 from src.drivers.modbus.models.mapping import MPGBPMapping
 from src.utils.model_utils import get_datetime
@@ -80,34 +81,28 @@ class PointStoreModel(PointStoreModelMixin, db.Model):
         updated: bool = bool(res.rowcount)
         if MqttRestBridge.status() and updated and sync:
             if driver == Drivers.GENERIC:
-                """
-                Generic Point value is updated, need to sync Modbus Point
-                Because: Modbus Point <> Generic | BACnet Point
-                """
-                FlaskThread(target=self.__sync_point_value_gp_mp, daemon=True).start()
-                """
-                Generic Point value is updated, need to sync BACnet Point
-                Because: Generic Point <> BACnet Point
-                """
-                FlaskThread(target=self.__sync_point_value_gp_bp, daemon=True).start()
+                """Generic > Modbus point value"""
+                self.__sync_point_value_gp_to_mp_process()
+                """Generic > BACnet point value"""
+                self.__sync_point_value_gp_to_bp_process()
             elif driver == Drivers.MODBUS:
-                """
-                Modbus Point value is updated, need to sync Generic & BACnet Point
-                Because: Modbus Point <> Generic | BACnet Point
-                """
-                FlaskThread(target=self.__sync_point_value_mp_gbp, daemon=True).start()
+                """Modbus > Generic | BACnet point value"""
+                self.__sync_point_value_mp_to_gbp_process()
         return updated
 
-    def __sync_point_value_gp_mp(self):
+    def __sync_point_value_gp_to_mp(self, modbus_point_uuid: str):
+        api_to_topic_mapper(
+            api=f"/api/modbus/points_value/uuid/{modbus_point_uuid}",
+            destination_identifier='ps',
+            body={"value": self.value},
+            http_method=HttpMethod.PATCH)
+
+    def __sync_point_value_gp_to_mp_process(self):
         mapping: MPGBPMapping = MPGBPMapping.find_by_generic_point_uuid(self.point_uuid)
         if mapping:
-            api_to_topic_mapper(
-                api=f"/api/modbus/points_value/uuid/{mapping.modbus_point_uuid}",
-                destination_identifier='ps',
-                body={"value": self.value},
-                http_method=HttpMethod.PATCH)
+            gevent.spawn(self.__sync_point_value_gp_to_mp, mapping.modbus_point_uuid)
 
-    def __sync_point_value_gp_bp(self):
+    def __sync_point_value_gp_to_bp(self):
         response: Response = api_to_topic_mapper(api=f"api/mappings/bp_gp/generic/{self.point_uuid}",
                                                  destination_identifier='bacnet',
                                                  http_method=HttpMethod.GET)
@@ -117,34 +112,39 @@ class PointStoreModel(PointStoreModelMixin, db.Model):
                                 body={"priority_array_write": {"_16": self.value}},
                                 http_method=HttpMethod.PATCH)
 
-    def sync_point_value_with_mapping_mp_gbp(self, mapping: MPGBPMapping, gp: bool = True, bp=True):
+    def __sync_point_value_gp_to_bp_process(self):
+        gevent.spawn(self.__sync_point_value_gp_to_bp())
+
+    def sync_point_value_with_mapping_mp_to_gbp(self, generic_point_uuid: str, bacnet_point_uuid: str,
+                                                gp: bool = True, bp: bool = True):
         if not MqttRestBridge.status():
             return
-        if mapping.generic_point_uuid and gp:
+        if generic_point_uuid and gp:
             api_to_topic_mapper(
-                api=f"/api/generic/points_value/uuid/{mapping.generic_point_uuid}",
+                api=f"/api/generic/points_value/uuid/{generic_point_uuid}",
                 destination_identifier='ps',
                 body={"value": self.value},
                 http_method=HttpMethod.PATCH)
-        elif mapping.bacnet_point_uuid and bp:
+        elif bacnet_point_uuid and bp:
             api_to_topic_mapper(
-                api=f"/api/bacnet/points/uuid/{mapping.bacnet_point_uuid}",
+                api=f"/api/bacnet/points/uuid/{bacnet_point_uuid}",
                 destination_identifier='bacnet',
                 body={"priority_array_write": {"_16": self.value}},
                 http_method=HttpMethod.PATCH)
 
-    def __sync_point_value_mp_gbp(self, gp: bool = True, bp=True):
+    def __sync_point_value_mp_to_gbp_process(self, gp: bool = True, bp: bool = True):
         mapping: MPGBPMapping = MPGBPMapping.find_by_modbus_point_uuid(self.point_uuid)
         if mapping:
-            self.sync_point_value_with_mapping_mp_gbp(mapping, gp, bp)
+            gevent.spawn(self.sync_point_value_with_mapping_mp_to_gbp,
+                         mapping.generic_point_uuid, mapping.bacnet_point_uuid,
+                         gp, bp)
 
     @classmethod
-    def sync_points_values_mp_gbp(cls, gp: bool = True, bp=True):
+    def sync_points_values_mp_to_gbp_process(cls, gp: bool = True, bp: bool = True):
         if not MqttRestBridge.status():
             return
         mappings: List[MPGBPMapping] = MPGBPMapping.find_all()
         for mapping in mappings:
             point_store: PointStoreModel = PointStoreModel.find_by_point_uuid(mapping.modbus_point_uuid)
             if point_store:
-                FlaskThread(target=point_store.__sync_point_value_mp_gbp, daemon=True,
-                            kwargs={'gp': gp, 'bp': bp}).start()
+                point_store.__sync_point_value_mp_to_gbp_process(gp, bp)

--- a/src/models/point/model_point_store.py
+++ b/src/models/point/model_point_store.py
@@ -46,7 +46,7 @@ class PointStoreModel(PointStoreModelMixin, db.Model):
         else:
             return None
 
-    def update(self, driver: Drivers, cov_threshold: float = None, sync: bool = True) -> bool:
+    def update(self, driver: Drivers, cov_threshold: float = None) -> bool:
         ts = get_datetime()
         if not self.fault:
             self.fault = bool(self.fault)
@@ -79,7 +79,7 @@ class PointStoreModel(PointStoreModelMixin, db.Model):
                 self.ts_fault = ts
         db.session.commit()
         updated: bool = bool(res.rowcount)
-        if MqttRestBridge.status() and updated and sync:
+        if MqttRestBridge.status() and updated:
             if driver == Drivers.GENERIC:
                 """Generic > Modbus point value"""
                 self.__sync_point_value_gp_to_mp_process()
@@ -140,8 +140,8 @@ class PointStoreModel(PointStoreModelMixin, db.Model):
                          gp, bp)
 
     @classmethod
-    def sync_points_values_mp_to_gbp_process(cls, gp: bool = True, bp: bool = True):
-        if not MqttRestBridge.status():
+    def sync_points_values_mp_to_gbp_process(cls, gp: bool = True, bp: bool = True, force_sync: bool = False):
+        if not MqttRestBridge.status() and not force_sync:
             return
         mappings: List[MPGBPMapping] = MPGBPMapping.find_all()
         for mapping in mappings:

--- a/src/models/point/model_point_store.py
+++ b/src/models/point/model_point_store.py
@@ -99,12 +99,12 @@ class PointStoreModel(PointStoreModelMixin, db.Model):
         return updated
 
     def __sync_point_value_gp_mp(self):
-        mapping: MPGBPMapping = MPGBPMapping.find_by_modbus_point_uuid(self.point_uuid)
+        mapping: MPGBPMapping = MPGBPMapping.find_by_generic_point_uuid(self.point_uuid)
         if mapping:
             api_to_topic_mapper(
-                api=f"/api/points/points_value/uuid/{mapping.modbus_point_uuid}",
-                destination_identifier='bacnet',
-                body={"priority_array_write": {"_16": self.value}},
+                api=f"/api/modbus/points_value/uuid/{mapping.modbus_point_uuid}",
+                destination_identifier='ps',
+                body={"value": self.value},
                 http_method=HttpMethod.PATCH)
 
     def __sync_point_value_gp_bp(self):
@@ -122,7 +122,7 @@ class PointStoreModel(PointStoreModelMixin, db.Model):
             return
         if mapping.generic_point_uuid and gp:
             api_to_topic_mapper(
-                api=f"/api/points/points_value/uuid/{mapping.generic_point_uuid}",
+                api=f"/api/generic/points_value/uuid/{mapping.generic_point_uuid}",
                 destination_identifier='ps',
                 body={"value": self.value},
                 http_method=HttpMethod.PATCH)

--- a/src/models/point/priority_array.py
+++ b/src/models/point/priority_array.py
@@ -25,8 +25,8 @@ class PriorityArrayModel(db.Model):
         return f"PriorityArray(uuid = {self.point_uuid})"
 
     @classmethod
-    def create_new_priority_array_model(cls, point_uuid):
-        return PriorityArrayModel(point_uuid=point_uuid)
+    def create_priority_array_model(cls, point_uuid, priority_array_write):
+        return PriorityArrayModel(point_uuid=point_uuid, **priority_array_write)
 
     @classmethod
     def filter_by_point_uuid(cls, point_uuid):
@@ -34,7 +34,11 @@ class PriorityArrayModel(db.Model):
 
     @classmethod
     def get_highest_priority_value(cls, point_uuid):
-        priority_array = cls.filter_by_point_uuid(point_uuid).first()
+        priority_array: dict = cls.filter_by_point_uuid(point_uuid).first()
+        return cls.get_highest_priority_value_from_dict(priority_array)
+
+    @classmethod
+    def get_highest_priority_value_from_dict(cls, priority_array: dict):
         if priority_array:
             for i in range(1, 17):
                 value = getattr(priority_array, f'_{i}')

--- a/src/models/point/priority_array.py
+++ b/src/models/point/priority_array.py
@@ -3,7 +3,7 @@ from src import db
 
 class PriorityArrayModel(db.Model):
     __tablename__ = 'priority_array'
-    generic_uuid = db.Column(db.String, db.ForeignKey('generic_points.uuid'), primary_key=True, nullable=False)
+    point_uuid = db.Column(db.String, db.ForeignKey('points.uuid'), primary_key=True, nullable=False)
     _1 = db.Column(db.Float(), nullable=True)
     _2 = db.Column(db.Float(), nullable=True)
     _3 = db.Column(db.Float(), nullable=True)
@@ -22,19 +22,19 @@ class PriorityArrayModel(db.Model):
     _16 = db.Column(db.Float(), nullable=True)
 
     def __repr__(self):
-        return f"PriorityArray(generic_uuid = {self.generic_uuid})"
+        return f"PriorityArray(uuid = {self.point_uuid})"
 
     @classmethod
-    def create_new_priority_array_model(cls, generic_uuid):
-        return PriorityArrayModel(generic_uuid=generic_uuid)
+    def create_new_priority_array_model(cls, point_uuid):
+        return PriorityArrayModel(point_uuid=point_uuid)
 
     @classmethod
-    def filter_by_point_uuid(cls, generic_uuid):
-        return cls.query.filter_by(generic_uuid=generic_uuid)
+    def filter_by_point_uuid(cls, point_uuid):
+        return cls.query.filter_by(point_uuid=point_uuid)
 
     @classmethod
-    def get_highest_priority_value(cls, generic_uuid):
-        priority_array = cls.filter_by_point_uuid(generic_uuid).first()
+    def get_highest_priority_value(cls, point_uuid):
+        priority_array = cls.filter_by_point_uuid(point_uuid).first()
         if priority_array:
             for i in range(1, 17):
                 value = getattr(priority_array, f'_{i}')

--- a/src/resources/resource_point_value_writer.py
+++ b/src/resources/resource_point_value_writer.py
@@ -9,7 +9,7 @@ from rubix_http.resource import RubixResource
 from src.models.point.model_point import PointModel
 
 
-class GenericPointValueWriterBase(RubixResource):
+class PointValueWriterBase(RubixResource):
     patch_parser = reqparse.RequestParser()
     patch_parser.add_argument('value', type=float, required=False)
     patch_parser.add_argument('value_raw', type=str, required=False)
@@ -24,7 +24,7 @@ class GenericPointValueWriterBase(RubixResource):
 
     @classmethod
     def patch(cls, **kwargs):
-        data = GenericPointValueWriterBase.patch_parser.parse_args()
+        data = PointValueWriterBase.patch_parser.parse_args()
         point: PointModel = cls.get_point(**kwargs)
         if not point:
             raise NotFoundException('Point does not exist')
@@ -39,13 +39,13 @@ class GenericPointValueWriterBase(RubixResource):
         return {}
 
 
-class GenericUUIDPointValueWriter(GenericPointValueWriterBase):
+class PointUUIDValueWriter(PointValueWriterBase):
     @classmethod
     def get_point(cls, **kwargs) -> PointModel:
         return PointModel.find_by_uuid(kwargs.get('uuid'))
 
 
-class GenericNamePointValueWriter(GenericPointValueWriterBase):
+class PointNameValueWriter(PointValueWriterBase):
     @classmethod
     def get_point(cls, **kwargs) -> PointModel:
         return PointModel.find_by_name(kwargs.get('network_name'), kwargs.get('device_name'), kwargs.get('point_name'))

--- a/src/resources/rest_schema/schema_point.py
+++ b/src/resources/rest_schema/schema_point.py
@@ -119,8 +119,8 @@ point_return_attributes = {
 }
 
 point_all_fields = {}
-map_rest_schema(point_return_attributes, point_all_fields)
 map_rest_schema(point_all_attributes, point_all_fields)
+map_rest_schema(point_return_attributes, point_all_fields)
 
 
 def add_nested_priority_array_write():

--- a/src/resources/rest_schema/schema_point.py
+++ b/src/resources/rest_schema/schema_point.py
@@ -1,6 +1,27 @@
+from collections import OrderedDict
+
 from flask_restful import fields
 
 from src.resources.utils import map_rest_schema
+
+priority_array_write_fields = OrderedDict({
+    '_1': fields.Float,
+    '_2': fields.Float,
+    '_3': fields.Float,
+    '_4': fields.Float,
+    '_5': fields.Float,
+    '_6': fields.Float,
+    '_7': fields.Float,
+    '_8': fields.Float,
+    '_9': fields.Float,
+    '_10': fields.Float,
+    '_11': fields.Float,
+    '_12': fields.Float,
+    '_13': fields.Float,
+    '_14': fields.Float,
+    '_15': fields.Float,
+    '_16': fields.Float,
+})
 
 point_store_fields = {
     'point_uuid': fields.String,
@@ -88,6 +109,9 @@ point_return_attributes = {
     },
     'updated_on': {
         'type': str,
+    },
+    'priority_array_write': {
+        'type': fields.Nested(priority_array_write_fields),
     },
     'point_store': {
         'type': fields.Nested(point_store_fields),

--- a/src/resources/rest_schema/schema_point.py
+++ b/src/resources/rest_schema/schema_point.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 
-from flask_restful import fields
+from flask_restful import fields, reqparse
 
 from src.resources.utils import map_rest_schema
 
@@ -61,8 +61,8 @@ point_all_attributes = {
     'writable': {
         'type': bool,
     },
-    'write_value': {
-        'type': float,
+    'priority_array_write': {
+        'type': dict,
     },
     'cov_threshold': {
         'type': float,
@@ -121,3 +121,23 @@ point_return_attributes = {
 point_all_fields = {}
 map_rest_schema(point_return_attributes, point_all_fields)
 map_rest_schema(point_all_attributes, point_all_fields)
+
+
+def add_nested_priority_array_write():
+    nested_priority_array_write_parser = reqparse.RequestParser()
+    nested_priority_array_write_parser.add_argument('_1', type=float, location=('priority_array_write',))
+    nested_priority_array_write_parser.add_argument('_2', type=float, location=('priority_array_write',))
+    nested_priority_array_write_parser.add_argument('_3', type=float, location=('priority_array_write',))
+    nested_priority_array_write_parser.add_argument('_4', type=float, location=('priority_array_write',))
+    nested_priority_array_write_parser.add_argument('_5', type=float, location=('priority_array_write',))
+    nested_priority_array_write_parser.add_argument('_6', type=float, location=('priority_array_write',))
+    nested_priority_array_write_parser.add_argument('_7', type=float, location=('priority_array_write',))
+    nested_priority_array_write_parser.add_argument('_8', type=float, location=('priority_array_write',))
+    nested_priority_array_write_parser.add_argument('_9', type=float, location=('priority_array_write',))
+    nested_priority_array_write_parser.add_argument('_10', type=float, location=('priority_array_write',))
+    nested_priority_array_write_parser.add_argument('_11', type=float, location=('priority_array_write',))
+    nested_priority_array_write_parser.add_argument('_12', type=float, location=('priority_array_write',))
+    nested_priority_array_write_parser.add_argument('_13', type=float, location=('priority_array_write',))
+    nested_priority_array_write_parser.add_argument('_14', type=float, location=('priority_array_write',))
+    nested_priority_array_write_parser.add_argument('_15', type=float, location=('priority_array_write',))
+    nested_priority_array_write_parser.add_argument('_16', type=float, location=('priority_array_write',))

--- a/src/routes.py
+++ b/src/routes.py
@@ -10,8 +10,6 @@ from src.drivers.generic.resources.network.network_singular import GenericNetwor
 from src.drivers.generic.resources.point.point_plural import GenericPointPlural
 from src.drivers.generic.resources.point.point_singular import GenericPointSingularByUUID, \
     GenericPointSingularByName
-from src.drivers.generic.resources.point.point_value_writer import GenericUUIDPointValueWriter, \
-    GenericNamePointValueWriter
 from src.drivers.modbus.resources.device.device_plural import ModbusDevicePlural
 from src.drivers.modbus.resources.device.device_singular import ModbusDeviceSingularByUUID, \
     ModbusDeviceSingularByName
@@ -30,6 +28,8 @@ from src.drivers.modbus.resources.point.point_stores import ModbusPointPluralPoi
 from src.resources.resource_device import DeviceResourceByUUID, DeviceResourceByName, DeviceResourceList
 from src.resources.resource_network import NetworkResourceByUUID, NetworkResourceByName, NetworkResourceList
 from src.resources.resource_point import PointResourceByUUID, PointResourceByName, PointResourceList
+from src.resources.resource_point_value_writer import PointUUIDValueWriter, \
+    PointNameValueWriter
 from src.resources.resource_schedule import ScheduleResourceByUUID, ScheduleResourceList
 from src.system.resources.memory import GetSystemMem
 from src.system.resources.ping import Ping
@@ -51,6 +51,9 @@ api_point = Api(bp_point)
 api_point.add_resource(PointResourceList, '')
 api_point.add_resource(PointResourceByUUID, '/uuid/<string:uuid>')
 api_point.add_resource(PointResourceByName, '/name/<string:network_name>/<string:device_name>/<string:point_name>')
+api_point.add_resource(PointUUIDValueWriter, '/points_value/uuid/<string:uuid>')
+api_point.add_resource(PointNameValueWriter,
+                       '/points_value/name/<string:network_name>/<string:device_name>/<string:point_name>')
 
 bp_generic = Blueprint('generic', __name__, url_prefix='/api/generic')
 api_generic = Api(bp_generic)
@@ -64,9 +67,6 @@ api_generic.add_resource(GenericPointPlural, '/points')
 api_generic.add_resource(GenericPointSingularByUUID, '/points/uuid/<string:uuid>')
 api_generic.add_resource(GenericPointSingularByName,
                          '/points/name/<string:network_name>/<string:device_name>/<string:point_name>')
-api_generic.add_resource(GenericUUIDPointValueWriter, '/points_value/uuid/<string:uuid>')
-api_generic.add_resource(GenericNamePointValueWriter,
-                         '/points_value/name/<string:network_name>/<string:device_name>/<string:point_name>')
 
 bp_modbus = Blueprint('modbus', __name__, url_prefix='/api/modbus')
 api_modbus = Api(bp_modbus)

--- a/src/routes.py
+++ b/src/routes.py
@@ -10,6 +10,8 @@ from src.drivers.generic.resources.network.network_singular import GenericNetwor
 from src.drivers.generic.resources.point.point_plural import GenericPointPlural
 from src.drivers.generic.resources.point.point_singular import GenericPointSingularByUUID, \
     GenericPointSingularByName
+from src.drivers.generic.resources.point.point_value_writer import GenericPointUUIDValueWriter, \
+    GenericPointNameValueWriter
 from src.drivers.modbus.resources.device.device_plural import ModbusDevicePlural
 from src.drivers.modbus.resources.device.device_singular import ModbusDeviceSingularByUUID, \
     ModbusDeviceSingularByName
@@ -25,11 +27,10 @@ from src.drivers.modbus.resources.point.point_singular import ModbusPointSingula
     ModbusPointSingularByName
 from src.drivers.modbus.resources.point.point_stores import ModbusPointPluralPointStore, ModbusPointStore, \
     ModbusDevicePointPluralPointStore
+from src.drivers.modbus.resources.point.point_value_writer import ModbusPointUUIDValueWriter, ModbusPointNameValueWriter
 from src.resources.resource_device import DeviceResourceByUUID, DeviceResourceByName, DeviceResourceList
 from src.resources.resource_network import NetworkResourceByUUID, NetworkResourceByName, NetworkResourceList
 from src.resources.resource_point import PointResourceByUUID, PointResourceByName, PointResourceList
-from src.resources.resource_point_value_writer import PointUUIDValueWriter, \
-    PointNameValueWriter
 from src.resources.resource_schedule import ScheduleResourceByUUID, ScheduleResourceList
 from src.system.resources.memory import GetSystemMem
 from src.system.resources.ping import Ping
@@ -51,9 +52,6 @@ api_point = Api(bp_point)
 api_point.add_resource(PointResourceList, '')
 api_point.add_resource(PointResourceByUUID, '/uuid/<string:uuid>')
 api_point.add_resource(PointResourceByName, '/name/<string:network_name>/<string:device_name>/<string:point_name>')
-api_point.add_resource(PointUUIDValueWriter, '/points_value/uuid/<string:uuid>')
-api_point.add_resource(PointNameValueWriter,
-                       '/points_value/name/<string:network_name>/<string:device_name>/<string:point_name>')
 
 bp_generic = Blueprint('generic', __name__, url_prefix='/api/generic')
 api_generic = Api(bp_generic)
@@ -67,6 +65,9 @@ api_generic.add_resource(GenericPointPlural, '/points')
 api_generic.add_resource(GenericPointSingularByUUID, '/points/uuid/<string:uuid>')
 api_generic.add_resource(GenericPointSingularByName,
                          '/points/name/<string:network_name>/<string:device_name>/<string:point_name>')
+api_generic.add_resource(GenericPointUUIDValueWriter, '/points_value/uuid/<string:uuid>')
+api_generic.add_resource(GenericPointNameValueWriter,
+                         '/points_value/name/<string:network_name>/<string:device_name>/<string:point_name>')
 
 bp_modbus = Blueprint('modbus', __name__, url_prefix='/api/modbus')
 api_modbus = Api(bp_modbus)
@@ -85,6 +86,9 @@ api_modbus.add_resource(ModbusPointPollNonExisting, '/poll/point')
 api_modbus.add_resource(ModbusPointPluralPointStore, '/point_stores')
 api_modbus.add_resource(ModbusPointStore, '/point_stores/<string:uuid>')
 api_modbus.add_resource(ModbusDevicePointPluralPointStore, '/<string:device_uuid>/point_stores')
+api_modbus.add_resource(ModbusPointUUIDValueWriter, '/points_value/uuid/<string:uuid>')
+api_modbus.add_resource(ModbusPointNameValueWriter,
+                        '/points_value/name/<string:network_name>/<string:device_name>/<string:point_name>')
 
 # Modbus <> Generic|BACnet points mappings
 bp_mapping_mp_gbp = Blueprint('mappings_mp_gbp', __name__, url_prefix='/api/mp_gbp/mappings')

--- a/src/routes.py
+++ b/src/routes.py
@@ -27,7 +27,7 @@ from src.drivers.modbus.resources.point.point_singular import ModbusPointSingula
     ModbusPointSingularByName
 from src.drivers.modbus.resources.point.point_stores import ModbusPointPluralPointStore, ModbusPointStore, \
     ModbusDevicePointPluralPointStore
-from src.drivers.modbus.resources.point.point_sync import MPBPSync
+from src.drivers.modbus.resources.point.point_sync import MPToBPSync
 from src.drivers.modbus.resources.point.point_value_writer import ModbusPointUUIDValueWriter, ModbusPointNameValueWriter
 from src.resources.resource_device import DeviceResourceByUUID, DeviceResourceByName, DeviceResourceList
 from src.resources.resource_network import NetworkResourceByUUID, NetworkResourceByName, NetworkResourceList
@@ -100,9 +100,9 @@ api_mapping_mp_gbp.add_resource(MPGBPMappingResourceByModbusPointUUID, '/modbus/
 api_mapping_mp_gbp.add_resource(MPGBPMappingResourceByGenericPointUUID, '/generic/<string:uuid>')
 api_mapping_mp_gbp.add_resource(MPGBPMappingResourceByBACnetPointUUID, '/bacnet/<string:uuid>')
 
-bp_sync_mp_bp = Blueprint('sync_mp_bp', __name__, url_prefix='/api/sync/mp_bp')
-api_sync_mp_bp = Api(bp_sync_mp_bp)
-api_sync_mp_bp.add_resource(MPBPSync, '')
+bp_sync = Blueprint('sync', __name__, url_prefix='/api/sync')
+api_sync = Api(bp_sync)
+api_sync.add_resource(MPToBPSync, '/mp_to_bp')
 
 bp_system = Blueprint('system', __name__, url_prefix='/api/system')
 api_system = Api(bp_system)

--- a/src/routes.py
+++ b/src/routes.py
@@ -92,7 +92,7 @@ api_modbus.add_resource(ModbusPointNameValueWriter,
                         '/points_value/name/<string:network_name>/<string:device_name>/<string:point_name>')
 
 # Modbus <> Generic|BACnet points mappings
-bp_mapping_mp_gbp = Blueprint('mappings_mp_gbp', __name__, url_prefix='/api/mp_gbp/mappings')
+bp_mapping_mp_gbp = Blueprint('mappings_mp_gbp', __name__, url_prefix='/api/mappings/mp_gbp')
 api_mapping_mp_gbp = Api(bp_mapping_mp_gbp)
 api_mapping_mp_gbp.add_resource(MPGBPMappingResourceList, '')
 api_mapping_mp_gbp.add_resource(MPGBPMappingResourceByUUID, '/uuid/<string:uuid>')

--- a/src/routes.py
+++ b/src/routes.py
@@ -27,6 +27,7 @@ from src.drivers.modbus.resources.point.point_singular import ModbusPointSingula
     ModbusPointSingularByName
 from src.drivers.modbus.resources.point.point_stores import ModbusPointPluralPointStore, ModbusPointStore, \
     ModbusDevicePointPluralPointStore
+from src.drivers.modbus.resources.point.point_sync import MPBPSync
 from src.drivers.modbus.resources.point.point_value_writer import ModbusPointUUIDValueWriter, ModbusPointNameValueWriter
 from src.resources.resource_device import DeviceResourceByUUID, DeviceResourceByName, DeviceResourceList
 from src.resources.resource_network import NetworkResourceByUUID, NetworkResourceByName, NetworkResourceList
@@ -98,6 +99,10 @@ api_mapping_mp_gbp.add_resource(MPGBPMappingResourceByUUID, '/uuid/<string:uuid>
 api_mapping_mp_gbp.add_resource(MPGBPMappingResourceByModbusPointUUID, '/modbus/<string:uuid>')
 api_mapping_mp_gbp.add_resource(MPGBPMappingResourceByGenericPointUUID, '/generic/<string:uuid>')
 api_mapping_mp_gbp.add_resource(MPGBPMappingResourceByBACnetPointUUID, '/bacnet/<string:uuid>')
+
+bp_sync_mp_bp = Blueprint('sync_mp_bp', __name__, url_prefix='/api/sync/mp_bp')
+api_sync_mp_bp = Api(bp_sync_mp_bp)
+api_sync_mp_bp.add_resource(MPBPSync, '')
 
 bp_system = Blueprint('system', __name__, url_prefix='/api/system')
 api_system = Api(bp_system)

--- a/src/services/event_service_base.py
+++ b/src/services/event_service_base.py
@@ -17,7 +17,7 @@ class EventType(IntEnum):
     DEVICE_MODEL = auto()
     NETWORK_MODEL = auto()
     SCHEDULE_MODEL = auto()
-    MAPPING_UPDATE = auto()
+    MAPPING_MODEL = auto()
     MQTT_DEBUG = auto()
     POINT_REGISTRY_UPDATE = auto()
     SCHEDULES = auto()


### PR DESCRIPTION
Related to: https://github.com/NubeIO/rubix-bacnet-server/pull/110, https://github.com/NubeIO/lora-raw/pull/67

Resolves: #264
Resolves: #188

### Summary

- Add priority array on all Modbus points as well
- Point value writer for both Modbus | Generic
- Two way binding between generic <> modbus points

### Postman collection:

https://www.getpostman.com/collections/9e18cddf568f0a57fbaa

### Frontend changes:

- `write_value` is removed out and have inserted `priority_array_write`.
   - `priority_array_write` example:

       ```
       "priority_array_write": {
            "_1": null,
            "_2": null,
            "_3": null,
            "_4": null,
            "_5": null,
            "_6": null,
            "_7": null,
            "_8": null,
            "_9": null,
            "_10": null,
            "_11": null,
            "_12": null,
            "_13": null,
            "_14": null,
            "_15": null,
            "_16": 16.9089
       }
       ```
- So main we have changes on:
   
   1.  Add point for modbus
   2. `poll/point` (when we write, we need to pass `priority_array_write`)
   3. Change mapping API from `/api/mp_gbp/mappings` to `/api/mappings/mp_gbp`