### PR TITLE
Modbus poll aggregation

### DIFF
--- a/src/drivers/modbus/models/device.py
+++ b/src/drivers/modbus/models/device.py
@@ -16,7 +16,7 @@ class ModbusDeviceModel(DeviceMixinModel):
     address = db.Column(db.Integer(), nullable=False)
     zero_based = db.Column(db.Boolean(), nullable=False, default=False)
     ping_point = db.Column(db.String(10))
-    supports_multiple_rw = db.Column(db.Boolean(), nullable=False, default=True)
+    supports_multiple_rw = db.Column(db.Boolean(), nullable=False, default=False)
     modbus_network_uuid_constraint = db.Column(db.String, nullable=False)
 
     __table_args__ = (

--- a/src/drivers/modbus/models/device.py
+++ b/src/drivers/modbus/models/device.py
@@ -16,6 +16,7 @@ class ModbusDeviceModel(DeviceMixinModel):
     address = db.Column(db.Integer(), nullable=False)
     zero_based = db.Column(db.Boolean(), nullable=False, default=False)
     ping_point = db.Column(db.String(10))
+    supports_multiple_rw = db.Column(db.Boolean(), nullable=False, default=True)
     modbus_network_uuid_constraint = db.Column(db.String, nullable=False)
 
     __table_args__ = (

--- a/src/drivers/modbus/models/point.py
+++ b/src/drivers/modbus/models/point.py
@@ -121,13 +121,14 @@ class ModbusPointModel(PointMixinModel):
         if not isinstance(data_type, ModbusDataType):
             data_type = ModbusDataType[self.data_type]
         if point_fc == ModbusFunctionCode.READ_DISCRETE_INPUTS or point_fc == ModbusFunctionCode.READ_COILS or \
-                point_fc == ModbusFunctionCode.WRITE_COIL or point_fc == ModbusFunctionCode.WRITE_COILS:
+                point_fc == ModbusFunctionCode.WRITE_COIL:
             data_type = ModbusDataType.DIGITAL
             self.data_type = ModbusDataType.DIGITAL
+            self.register_length = 1
             self.value_round = 0
 
         if data_type == ModbusDataType.FLOAT or data_type == ModbusDataType.INT32 or \
                 data_type == ModbusDataType.UINT32:
-            assert reg_length % 2 == 0, f'register_length invalid for data_type {data_type}'
+            self.register_length = 2
 
         return True

--- a/src/drivers/modbus/resources/rest_schema/schema_modbus_device.py
+++ b/src/drivers/modbus/resources/rest_schema/schema_modbus_device.py
@@ -12,6 +12,9 @@ modbus_device_all_attributes['zero_based'] = {
 modbus_device_all_attributes['ping_point'] = {
     'type': str,
 }
+modbus_device_all_attributes['supports_multiple_rw'] = {
+    'type': bool,
+}
 
 modbus_device_return_attributes = deepcopy(device_return_attributes)
 modbus_device_return_attributes['type'] = {

--- a/src/drivers/modbus/services/polling/function_utils.py
+++ b/src/drivers/modbus/services/polling/function_utils.py
@@ -1,7 +1,10 @@
+from typing import List
+
 from pymodbus.constants import Endian
 from pymodbus.payload import BinaryPayloadDecoder, BinaryPayloadBuilder
 
 from src.drivers.modbus.enums.point.points import ModbusDataEndian, ModbusDataType
+from src.drivers.modbus.models.point import ModbusPointModel
 
 
 def _set_data_length(data_type: ModbusDataType, reg_length: int) -> int:
@@ -58,7 +61,7 @@ def convert_to_data_type(data, data_type: ModbusDataType, byteorder: Endian, wor
     Converts the data to int, int32, float and so on
     :return: value in the selected data type
     """
-    decoder = BinaryPayloadDecoder.fromRegisters(data.registers, byteorder=byteorder,
+    decoder = BinaryPayloadDecoder.fromRegisters(data, byteorder=byteorder,
                                                  wordorder=word_order)
     value = None
     if data_type == ModbusDataType.INT16:
@@ -95,3 +98,11 @@ def _builder_data_type(payload, data_type: ModbusDataType, byteorder: Endian, wo
     elif data_type == ModbusDataType.DOUBLE:
         builder.add_64bit_float(payload)
     return builder.to_registers()
+
+
+def pack_point_write_registers(point_list: List[ModbusPointModel]):
+    final_payload = []
+    for point in point_list:
+        byteorder, word_order = _mod_point_data_endian(point.data_endian)
+        final_payload.extend(_builder_data_type(point.write_value, point.data_type, byteorder, word_order))
+    return final_payload

--- a/src/drivers/modbus/services/polling/functions.py
+++ b/src/drivers/modbus/services/polling/functions.py
@@ -95,6 +95,8 @@ def write_digital(client: BaseModbusClient, reg_start: int, reg_length: int, _un
     debug_log('write_digital', _unit, func, reg_length, reg_start)
     data_type: ModbusDataType = ModbusDataType.DIGITAL
     reg_length: int = _set_data_length(data_type, reg_length)
+    for i in range(len(write_values)):
+        write_values[i] = int(write_values[i])
     if func == ModbusFunctionCode.WRITE_COIL:
         write = client.write_coil(reg_start, int(write_values[0]), unit=_unit)
     elif func == ModbusFunctionCode.WRITE_COILS:

--- a/src/drivers/modbus/services/polling/modbus_polling.py
+++ b/src/drivers/modbus/services/polling/modbus_polling.py
@@ -103,6 +103,7 @@ class ModbusPolling(EventServiceBase):
             points: List[ModbusPointModel] = self.__get_all_device_points(device.uuid)
 
             if not device.supports_multiple_rw:
+                self.__log_debug(f'Device {device.uuid} aggregate R/W UNSUPPORTED')
                 for point in points:
                     try:
                         self.__poll_point(current_connection.client, network, device, [point])
@@ -112,6 +113,7 @@ class ModbusPolling(EventServiceBase):
                         pass
                     time.sleep(float(network.point_interval_ms_between_points) / 1000)
             else:
+                self.__log_debug(f'Device {device.uuid} aggregate R/W SUPPORTED')
                 """
                 group and sort points into corresponding FCs
                 """

--- a/src/drivers/modbus/services/polling/poll.py
+++ b/src/drivers/modbus/services/polling/poll.py
@@ -53,7 +53,7 @@ def poll_point_aggregate(service: EventServiceBase, client: BaseModbusClient, ne
 
     arr_ind = 0
     val = 0
-    arr_slice = array[0:1]
+    arr_slice = None if array is None else array[0:1]
     for point in point_slice:
         point_store_new = None
         if not fault:

--- a/src/drivers/modbus/services/polling/poll.py
+++ b/src/drivers/modbus/services/polling/poll.py
@@ -53,20 +53,27 @@ def poll_point_aggregate(service: EventServiceBase, client: BaseModbusClient, ne
 
     arr_ind = 0
     val = 0
+    arr_slice = array[0:1]
     for point in point_slice:
         point_store_new = None
         if not fault:
 
             if point.data_type is not ModbusDataType.RAW and point.data_type is not ModbusDataType.DIGITAL:
                 byteorder, word_order = _mod_point_data_endian(point.data_endian)
-                val = convert_to_data_type(array[arr_ind:arr_ind+point.register_length], point.data_type, byteorder,
+                arr_slice = array[arr_ind:arr_ind+point.register_length]
+                val = convert_to_data_type(arr_slice, point.data_type, byteorder,
                                            word_order)
-            else:
+            elif point.data_type is ModbusDataType.DIGITAL:
+                arr_slice = array[arr_ind:arr_ind+1]
                 val = array[arr_ind]
+            else:
+                arr_slice = array[arr_ind:point.register_length]
+                val = array[arr_ind]
+
             arr_ind += point.register_length
 
             if isinstance(val, numbers.Number):
-                point_store_new = PointStoreModel(value_original=float(str(val)), value_raw=str(array),
+                point_store_new = PointStoreModel(value_original=float(str(val)), value_raw=str(arr_slice),
                                                   point_uuid=point.uuid)
             else:
                 fault_message = f"Received not numeric value, type is: {type(val)}"

--- a/src/drivers/modbus/services/polling/poll.py
+++ b/src/drivers/modbus/services/polling/poll.py
@@ -1,5 +1,6 @@
 import logging
 import numbers
+from typing import List
 
 from pymodbus.client.sync import BaseModbusClient
 from pymodbus.exceptions import ModbusIOException
@@ -9,11 +10,80 @@ from src.drivers.modbus.models.device import ModbusDeviceModel
 from src.drivers.modbus.models.network import ModbusNetworkModel
 from src.drivers.modbus.models.point import ModbusPointModel
 from src.drivers.modbus.services.polling.functions import read_digital, write_digital, \
-    read_analogue, write_analogue
+    read_analogue, write_analogue, write_analogue_aggregate
+from src.drivers.modbus.services.polling.function_utils import _mod_point_data_endian, convert_to_data_type, \
+    pack_point_write_registers
 from src.models.point.model_point_store import PointStoreModel
 from src.services.event_service_base import EventServiceBase
 
 logger = logging.getLogger(__name__)
+
+
+def poll_point_aggregate(service: EventServiceBase, client: BaseModbusClient, network: ModbusNetworkModel,
+                         device: ModbusDeviceModel, point_slice) -> None:
+    device_address: int = device.address
+    zero_based: bool = device.zero_based
+    point_register: int = point_slice[0].register
+    point_register_length = 0
+    write_values = []
+    for point in point_slice:
+        point_register_length += point.register_length
+        write_values.append(point.write_value)
+    point_fc: ModbusFunctionCode = point_slice[0].function_code
+    if point_fc is ModbusFunctionCode.WRITE_COIL:
+        point_fc = ModbusFunctionCode.WRITE_COILS
+    elif point_fc is ModbusFunctionCode.WRITE_REGISTER:
+        point_fc = ModbusFunctionCode.WRITE_REGISTERS
+    if point_fc is ModbusFunctionCode.WRITE_REGISTERS:
+        write_values = pack_point_write_registers(point_slice)
+    point_data_endian: ModbusDataEndian = point_slice[0].data_endian
+
+    array = None
+    fault = False
+    error = None
+    try:
+        val, array = __poll_point(client, device_address, zero_based, point_register, point_register_length, point_fc,
+                                  ModbusDataType.RAW, point_data_endian, write_values)
+
+    except ModbusIOException as e:
+        logger.error(str(e))
+        fault = True
+        fault_message = str(e)
+        error = e
+
+    arr_ind = 0
+    val = 0
+    for point in point_slice:
+        point_store_new = None
+        if not fault:
+
+            if point.data_type is not ModbusDataType.RAW and point.data_type is not ModbusDataType.DIGITAL:
+                byteorder, word_order = _mod_point_data_endian(point.data_endian)
+                val = convert_to_data_type(array[arr_ind:arr_ind+point.register_length], point.data_type, byteorder,
+                                           word_order)
+            else:
+                val = array[arr_ind]
+            arr_ind += point.register_length
+
+            if isinstance(val, numbers.Number):
+                point_store_new = PointStoreModel(value_original=float(str(val)), value_raw=str(array),
+                                                  point_uuid=point.uuid)
+            else:
+                fault_message = f"Received not numeric value, type is: {type(val)}"
+                fault = True
+                logger.error(fault_message)
+
+        if not point_store_new:
+            point_store_new = PointStoreModel(fault=fault, fault_message=fault_message, point_uuid=point.uuid)
+
+        try:
+            if point.update_point_value(point_store_new):
+                point.publish_cov(point_store_new, device, network, service.service_name)
+        except BaseException as e:
+            logger.error(e)
+
+    if error is not None:
+        raise error
 
 
 def poll_point(service: EventServiceBase, client: BaseModbusClient, network: ModbusNetworkModel,
@@ -32,30 +102,11 @@ def poll_point(service: EventServiceBase, client: BaseModbusClient, network: Mod
     device_address: int = device.address
     zero_based: bool = device.zero_based
     point_register: int = point.register
-    point_uuid: str = point.uuid
     point_register_length: int = point.register_length
     point_fc: ModbusFunctionCode = point.function_code
     point_data_type: ModbusDataType = point.data_type
     point_data_endian: ModbusDataEndian = point.data_endian
     write_value: float = point.write_value if point.write_value else 0
-
-    logger.debug('--------------- START MODBUS POLL POINT ---------------')
-    logger.debug({'network': network,
-                  'device_uuid': device.uuid,
-                  'device_address': device_address,
-                  'point_uuid': point_uuid,
-                  'point_fc': point_fc,
-                  'point_register': point_register,
-                  'point_register_length': point_register_length,
-                  'point_data_type': point_data_type,
-                  'point_data_endian': point_data_endian,
-                  'writable': point.writable,
-                  'write_value': write_value
-                  })
-    # TODO need to confirm, looks suspicious
-    if not zero_based:
-        point_register -= 1
-        logger.debug(f"Device zero_based True, [point_register - 1 = {point_register}]")
 
     fault: bool = False
     fault_message: str = ""
@@ -63,46 +114,11 @@ def poll_point(service: EventServiceBase, client: BaseModbusClient, network: Mod
     error = None
 
     try:
-        val = None
-        array = ""
-
-        if point_fc in [ModbusFunctionCode.READ_COILS, ModbusFunctionCode.READ_DISCRETE_INPUTS]:
-            val, array = read_digital(client,
-                                      point_register,
-                                      point_register_length,
-                                      device_address,
-                                      point_fc)
-
-        elif point_fc in [ModbusFunctionCode.READ_HOLDING_REGISTERS, ModbusFunctionCode.READ_INPUT_REGISTERS]:
-            val, array = read_analogue(client,
-                                       point_register,
-                                       point_register_length,
-                                       device_address,
-                                       point_data_type,
-                                       point_data_endian,
-                                       point_fc)
-
-        elif point_fc in [ModbusFunctionCode.WRITE_COIL, ModbusFunctionCode.WRITE_COILS]:
-            val, array = write_digital(client, point_register,
-                                       point_register_length,
-                                       device_address,
-                                       int(write_value),
-                                       point_fc)
-        elif point_fc in [ModbusFunctionCode.WRITE_REGISTER, ModbusFunctionCode.WRITE_REGISTERS]:
-            val, array = write_analogue(client,
-                                        point_register,
-                                        point_register_length,
-                                        device_address,
-                                        point_data_type,
-                                        point_data_endian,
-                                        write_value,
-                                        point_fc)
-
-        logger.debug(f'READ/WRITE SUCCESS: val: {val}, array: {array}')
+        val, array = __poll_point(client, device_address, zero_based, point_register, point_register_length, point_fc,
+                                  point_data_type, point_data_endian, [write_value])
 
         if isinstance(val, numbers.Number):
-            point_store_new = PointStoreModel(value_original=float(str(val)),
-                                              value_raw=str(array),
+            point_store_new = PointStoreModel(value_original=float(str(val)), value_raw=str(array),
                                               point_uuid=point.uuid)
         else:
             fault_message = f"Received not numeric value, type is: {type(val)}"
@@ -117,7 +133,6 @@ def poll_point(service: EventServiceBase, client: BaseModbusClient, network: Mod
 
     if not point_store_new:
         point_store_new = PointStoreModel(fault=fault, fault_message=fault_message, point_uuid=point.uuid)
-    logger.debug("--------------- END MODBUS POLL POINT ---------------")
 
     if update:
         try:
@@ -132,3 +147,69 @@ def poll_point(service: EventServiceBase, client: BaseModbusClient, network: Mod
         raise error
 
     return point_store_new
+
+
+def __poll_point(client: BaseModbusClient, device_address: int, zero_based: bool,
+                 point_register: int, point_register_length: int, point_fc: ModbusFunctionCode,
+                 point_data_type: ModbusDataType, point_data_endian: ModbusDataEndian, write_values: List[float]):
+    logger.debug('--------------- START MODBUS POLL POINT ---------------')
+    logger.debug({'device_address': device_address,
+                  'point_fc': point_fc,
+                  'point_register': point_register,
+                  'point_register_length': point_register_length,
+                  'point_data_type': point_data_type,
+                  'point_data_endian': point_data_endian,
+                  'write_values': write_values
+                  })
+    # TODO need to confirm, looks suspicious
+    if not zero_based:
+        point_register -= 1
+        logger.debug(f"Device zero_based True, [point_register - 1 = {point_register}]")
+
+    val = None
+    array = ""
+
+    if point_fc in [ModbusFunctionCode.READ_COILS, ModbusFunctionCode.READ_DISCRETE_INPUTS]:
+        val, array = read_digital(client,
+                                  point_register,
+                                  point_register_length,
+                                  device_address,
+                                  point_fc)
+
+    elif point_fc in [ModbusFunctionCode.READ_HOLDING_REGISTERS, ModbusFunctionCode.READ_INPUT_REGISTERS]:
+        val, array = read_analogue(client,
+                                   point_register,
+                                   point_register_length,
+                                   device_address,
+                                   point_data_type,
+                                   point_data_endian,
+                                   point_fc)
+
+    elif point_fc in [ModbusFunctionCode.WRITE_COIL, ModbusFunctionCode.WRITE_COILS]:
+        val, array = write_digital(client, point_register,
+                                   point_register_length,
+                                   device_address,
+                                   write_values,
+                                   point_fc)
+    elif point_fc == ModbusFunctionCode.WRITE_REGISTER or (point_fc == ModbusFunctionCode.WRITE_REGISTERS and
+                                                           point_data_type is not ModbusDataType.RAW):
+        val, array = write_analogue(client,
+                                    point_register,
+                                    point_register_length,
+                                    device_address,
+                                    point_data_type,
+                                    point_data_endian,
+                                    write_values[0],
+                                    point_fc)
+    elif point_fc is ModbusFunctionCode.WRITE_REGISTERS and point_data_type is ModbusDataType.RAW:
+        val, array = write_analogue_aggregate(client,
+                                              point_register,
+                                              point_register_length,
+                                              device_address,
+                                              write_values,
+                                              point_fc)
+
+    logger.debug(f'READ/WRITE SUCCESS: val: {val}, array: {array}')
+    logger.debug("--------------- END MODBUS POLL POINT ---------------")
+
+    return val, array


### PR DESCRIPTION
### Aggregate contiguous modbus points into singe request
- `ModbusDeviceModel` now has `supports_multiple_rw` (read/write) field that enables/disables aggregation
- Sorts device points into function codes and joins any contiguous points into single request
- Resolves #269 by not skipping sleep on errors