### PR TITLE
Add tags to generic network and device

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -36,7 +36,7 @@
     "ssl_mode": "allow",
     "connect_timeout": 5,
     "timer": 1,
-    "table_name": "points",
+    "table_prefix": "tbl",
     "attempt_reconnect_secs": 5
   },
   "mqtt_rest_bridge_listener": {

--- a/src/drivers/generic/models/device.py
+++ b/src/drivers/generic/models/device.py
@@ -1,9 +1,38 @@
+import json
+import re
+
+from sqlalchemy.orm import validates
+
+from src import db
 from src.drivers.enums.drivers import Drivers
 from src.models.device.model_device_mixin import DeviceMixinModel
 
 
 class GenericDeviceModel(DeviceMixinModel):
     __tablename__ = 'generic_devices'
+    tags = db.Column(db.String(320), nullable=True)
+
+    @validates('tags')
+    def validate_tags(self, _, value):
+        """
+        Rules for tags:
+        - force all tags to be lower case
+        - if there is a gap add an underscore
+        - no special characters
+        """
+        if value is not None:
+            try:
+                tags = json.loads(value)
+                return_tags: dict = {}
+                for tag in tags:
+                    clean_tag: str = tag.lower()
+                    clean_tag = clean_tag.replace(" ", "_")
+                    clean_tag = re.sub('[^A-Za-z0-9_]+', '', clean_tag)
+                    return_tags[clean_tag] = tags[tag]
+                return json.dumps(return_tags)
+            except ValueError:
+                raise ValueError('tags needs to be a valid JSON')
+        return value
 
     @classmethod
     def get_polymorphic_identity(cls) -> Drivers:

--- a/src/drivers/generic/models/device.py
+++ b/src/drivers/generic/models/device.py
@@ -1,11 +1,9 @@
-import json
-import re
-
 from sqlalchemy.orm import validates
 
 from src import db
 from src.drivers.enums.drivers import Drivers
 from src.models.device.model_device_mixin import DeviceMixinModel
+from src.utils.model_utils import validate_json
 
 
 class GenericDeviceModel(DeviceMixinModel):
@@ -22,14 +20,7 @@ class GenericDeviceModel(DeviceMixinModel):
         """
         if value is not None:
             try:
-                tags = json.loads(value)
-                return_tags: dict = {}
-                for tag in tags:
-                    clean_tag: str = tag.lower()
-                    clean_tag = clean_tag.replace(" ", "_")
-                    clean_tag = re.sub('[^A-Za-z0-9_]+', '', clean_tag)
-                    return_tags[clean_tag] = tags[tag]
-                return json.dumps(return_tags)
+                return validate_json(value)
             except ValueError:
                 raise ValueError('tags needs to be a valid JSON')
         return value

--- a/src/drivers/generic/models/network.py
+++ b/src/drivers/generic/models/network.py
@@ -1,9 +1,38 @@
+import json
+import re
+
+from sqlalchemy.orm import validates
+
+from src import db
 from src.drivers.enums.drivers import Drivers
 from src.models.network.model_network_mixin import NetworkMixinModel
 
 
 class GenericNetworkModel(NetworkMixinModel):
     __tablename__ = 'generic_networks'
+    tags = db.Column(db.String(320), nullable=True)
+
+    @validates('tags')
+    def validate_tags(self, _, value):
+        """
+        Rules for tags:
+        - force all tags to be lower case
+        - if there is a gap add an underscore
+        - no special characters
+        """
+        if value is not None:
+            try:
+                tags = json.loads(value)
+                return_tags: dict = {}
+                for tag in tags:
+                    clean_tag: str = tag.lower()
+                    clean_tag = clean_tag.replace(" ", "_")
+                    clean_tag = re.sub('[^A-Za-z0-9_]+', '', clean_tag)
+                    return_tags[clean_tag] = tags[tag]
+                return json.dumps(return_tags)
+            except ValueError:
+                raise ValueError('tags needs to be a valid JSON')
+        return value
 
     @classmethod
     def get_polymorphic_identity(cls) -> Drivers:

--- a/src/drivers/generic/models/network.py
+++ b/src/drivers/generic/models/network.py
@@ -1,11 +1,9 @@
-import json
-import re
-
 from sqlalchemy.orm import validates
 
 from src import db
 from src.drivers.enums.drivers import Drivers
 from src.models.network.model_network_mixin import NetworkMixinModel
+from src.utils.model_utils import validate_json
 
 
 class GenericNetworkModel(NetworkMixinModel):
@@ -22,14 +20,7 @@ class GenericNetworkModel(NetworkMixinModel):
         """
         if value is not None:
             try:
-                tags = json.loads(value)
-                return_tags: dict = {}
-                for tag in tags:
-                    clean_tag: str = tag.lower()
-                    clean_tag = clean_tag.replace(" ", "_")
-                    clean_tag = re.sub('[^A-Za-z0-9_]+', '', clean_tag)
-                    return_tags[clean_tag] = tags[tag]
-                return json.dumps(return_tags)
+                return validate_json(value)
             except ValueError:
                 raise ValueError('tags needs to be a valid JSON')
         return value

--- a/src/drivers/generic/resources/rest_schema/schema_generic_device.py
+++ b/src/drivers/generic/resources/rest_schema/schema_generic_device.py
@@ -2,9 +2,13 @@ from src.drivers.generic.resources.rest_schema.schema_generic_point import gener
 from src.resources.rest_schema.schema_device import *
 
 generic_device_all_attributes = deepcopy(device_all_attributes)
-
+generic_device_all_attributes['tags'] = {
+    'type': str,
+}
 generic_device_return_attributes = deepcopy(device_return_attributes)
-
+generic_device_return_attributes['tags'] = {
+    'type': str,
+}
 generic_device_all_fields = {}
 map_rest_schema(generic_device_return_attributes, generic_device_all_fields)
 map_rest_schema(generic_device_all_attributes, generic_device_all_fields)

--- a/src/drivers/generic/resources/rest_schema/schema_generic_network.py
+++ b/src/drivers/generic/resources/rest_schema/schema_generic_network.py
@@ -3,8 +3,13 @@ from src.drivers.generic.resources.rest_schema.schema_generic_device import \
 from src.resources.rest_schema.schema_network import *
 
 generic_network_all_attributes = deepcopy(network_all_attributes)
-
+generic_network_all_attributes['tags'] = {
+    'type': str,
+}
 generic_network_return_attributes = deepcopy(network_return_attributes)
+generic_network_all_attributes['tags'] = {
+    'type': str,
+}
 
 generic_network_all_fields = {}
 map_rest_schema(generic_network_return_attributes, generic_network_all_fields)

--- a/src/models/point/model_point.py
+++ b/src/models/point/model_point.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import random
 import re
@@ -18,6 +17,7 @@ from src.models.point.model_point_store_history import PointStoreHistoryModel
 from src.models.point.priority_array import PriorityArrayModel
 from src.services.event_service_base import Event, EventType
 from src.utils.math_functions import eval_arithmetic_expression
+from src.utils.model_utils import validate_json
 
 logger = logging.getLogger(__name__)
 
@@ -112,14 +112,7 @@ class PointModel(ModelBase):
         """
         if value is not None:
             try:
-                tags = json.loads(value)
-                return_tags: dict = {}
-                for tag in tags:
-                    clean_tag: str = tag.lower()
-                    clean_tag = clean_tag.replace(" ", "_")
-                    clean_tag = re.sub('[^A-Za-z0-9_]+', '', clean_tag)
-                    return_tags[clean_tag] = tags[tag]
-                return json.dumps(return_tags)
+                return validate_json(value)
             except ValueError:
                 raise ValueError('tags needs to be a valid JSON')
         return value

--- a/src/setting.py
+++ b/src/setting.py
@@ -96,7 +96,7 @@ class PostgresSetting(BaseSetting):
         self.ssl_mode = 'allow'
         self.connect_timeout = 5
         self.timer = 1
-        self.table_name = 'points'
+        self.table_prefix = 'tbl'
         self.attempt_reconnect_secs = 5
 
 

--- a/src/utils/model_utils.py
+++ b/src/utils/model_utils.py
@@ -1,3 +1,5 @@
+import json
+import re
 from datetime import datetime
 
 
@@ -31,3 +33,20 @@ def datetime_to_str(datetime_obj: datetime or None) -> str:
         return datetime_obj.strftime("%Y-%m-%d %H:%M:%S")
     else:
         return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def validate_json(value: str):
+    """
+    Rules for valid json:
+    - force all json to be lower case
+    - if there is a gap add an underscore
+    - no special characters
+    """
+    objects = json.loads(value)
+    return_value: dict = {}
+    for obj in objects:
+        clean_obj: str = obj.lower()
+        clean_obj = clean_obj.replace(" ", "_")
+        clean_obj = re.sub('[^A-Za-z0-9_]+', '', clean_obj)
+        return_value[clean_obj] = objects[obj]
+    return json.dumps(return_value)

--- a/tests/setting_dump.py
+++ b/tests/setting_dump.py
@@ -38,7 +38,7 @@ if __name__ == '__main__':
         "ssl_mode": "allow",
         "connect_timeout": 5,
         "timer": 1,
-        "table_name": "point",
+        "table_prefix": "tbl",
         "attempt_reconnect_secs": 5
       },
       "generic_point_listener": {


### PR DESCRIPTION
Resolves: #291
### Summary:
- Added tags field for generic network and device.
- Added tags schema in `/api/generic/networks` and `/api/generic/devices` endpoints for POST, PUT and PATCH. Example:
```
{
  tags:{\"test& 1\": 1,\"test& 2\": \"2\",\"test & 3\": false}
}
```
