### PR TITLE
Improvement/change automatic tag keys

### DIFF
--- a/src/services/histories/sync/influxdb.py
+++ b/src/services/histories/sync/influxdb.py
@@ -97,13 +97,13 @@ class InfluxDB(HistoryBinding, metaclass=Singleton):
                     for point_tag in point_tags:
                         tags[point_tag] = point_tags[point_tag]
                 tags.update({
-                    'point_uuid': point.uuid,
-                    'point_name': point.name,
-                    'edge_device_uuid': point.device.uuid,
-                    'edge_device_name': point.device.name,
-                    'network_uuid': point.device.network.uuid,
-                    'network_name': point.device.network.name,
-                    'driver': point.driver.name,
+                    'rubix_point_uuid': point.uuid,
+                    'rubix_point_name': point.name,
+                    'rubix_device_uuid': point.device.uuid,
+                    'rubix_device_name': point.device.name,
+                    'rubix_network_uuid': point.device.network.uuid,
+                    'rubix_network_name': point.device.network.name,
+                    'rubix_driver': point.driver.name,
                 })
                 fields = {
                     'id': point_store_history.id,

--- a/src/services/histories/sync/postgresql.py
+++ b/src/services/histories/sync/postgresql.py
@@ -115,7 +115,7 @@ class PostgreSQL(HistoryBinding, metaclass=Singleton):
             _point: tuple = (point.device.network.uuid, point.device.uuid,
                              point.uuid, point.driver.name, point.name)
             points_list.append(_point)
-            
+
             if point.tags:
                 point_tags: dict = json.loads(point.tags)
                 # insert tags from point object
@@ -185,8 +185,7 @@ class PostgreSQL(HistoryBinding, metaclass=Singleton):
 
                     except psycopg2.Error as e:
                         logger.error(str(e))
-            logger.info(f'Stored/updated 1 rows on '
-                        f'{self.__wires_plat_table_name} table')
+            logger.info(f'Stored/updated 1 rows on {self.__wires_plat_table_name} table')
         else:
             logger.debug(f"Nothing to store on {self.__wires_plat_table_name}")
 


### PR DESCRIPTION
Resolves: #329 
### Summary:
- Changed tag keys:
  - point_uuid -> rubix_point_uuid
  - point_name -> rubix_point_name
  - device_uuid -> rubix_device_uuid
  - device_name -> rubix_device_name
  - network_uuid -> rubix_network_uuid
  - network_name -> rubix_network_name
  - driver -> rubix_driver