### PR TITLE
Use shortuuid Schecule and Mapping (uuid4 with URL supporting base57 encoding)

### DIFF
--- a/src/drivers/modbus/resources/mapping/mapping.py
+++ b/src/drivers/modbus/resources/mapping/mapping.py
@@ -1,4 +1,4 @@
-import uuid as uuid_
+import shortuuid
 from abc import abstractmethod
 
 from flask_restful import marshal_with, reqparse
@@ -33,7 +33,7 @@ class MPGBPMappingResourceList(RubixResource):
                                 required=mapping_mp_gbp_attributes[attr].get('required', False),
                                 default=None)
         data = parser.parse_args()
-        data.uuid = str(uuid_.uuid4())
+        data.uuid = str(shortuuid.uuid())
         mapping: MPGBPMapping = MPGBPMapping(**data)
         mapping.save_to_db()
         sync_point_value(mapping)

--- a/src/resources/resource_schedule.py
+++ b/src/resources/resource_schedule.py
@@ -1,4 +1,4 @@
-import uuid as uuid_
+import shortuuid
 from abc import abstractmethod
 
 from flask_restful import marshal_with, reqparse
@@ -20,7 +20,7 @@ class ScheduleResourceBase(RubixResource):
 
     @classmethod
     def add_schedule(cls, data):
-        uuid = str(uuid_.uuid4())
+        uuid = str(shortuuid.uuid())
         schedule = ScheduleModel(uuid=uuid, **data)
         schedule.save_to_db()
         return schedule


### PR DESCRIPTION
### Summary:
  - Changed uuid to shortuuid in Schedule and Mapping.