### PR TITLE
Make server schedule available on the local broker.

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -41,6 +41,7 @@
   "mqtt": [
     {
       "enabled": true,
+      "cloud": false,
       "name": "rubix-points",
       "host": "0.0.0.0",
       "port": 1883,
@@ -58,8 +59,7 @@
       "listen": true,
       "listen_topic": "rubix/points/listen",
       "publish_debug": true,
-      "debug_topic": "rubix/points/debug",
-      "cloud": false
+      "debug_topic": "rubix/points/debug"
     }
   ]
 }

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -59,7 +59,7 @@
       "listen_topic": "rubix/points/listen",
       "publish_debug": true,
       "debug_topic": "rubix/points/debug",
-      "cloud": true
+      "cloud": false
     }
   ]
 }

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -58,7 +58,8 @@
       "listen": true,
       "listen_topic": "rubix/points/listen",
       "publish_debug": true,
-      "debug_topic": "rubix/points/debug"
+      "debug_topic": "rubix/points/debug",
+      "cloud": true
     }
   ]
 }

--- a/src/services/event_service_base.py
+++ b/src/services/event_service_base.py
@@ -18,6 +18,7 @@ class EventType(IntEnum):
     MQTT_DEBUG = auto()
     POINT_REGISTRY_UPDATE = auto()
     SCHEDULES = auto()
+    SCHEDULE_VALUE = auto()
 
 
 # TODO: implement event queue overload warning and clearing

--- a/src/services/mqtt_client/mqtt_client.py
+++ b/src/services/mqtt_client/mqtt_client.py
@@ -39,6 +39,7 @@ class MqttClient(MqttListener, EventServiceBase):
         self.supported_events[EventType.MQTT_DEBUG] = True
         self.supported_events[EventType.POINT_REGISTRY_UPDATE] = True
         self.supported_events[EventType.SCHEDULES] = True
+        self.supported_events[EventType.SCHEDULE_VALUE] = True
 
     @property
     def config(self) -> MqttSetting:
@@ -104,6 +105,8 @@ class MqttClient(MqttListener, EventServiceBase):
 
         elif event.event_type == EventType.SCHEDULES and self.config.publish_value:
             self._publish_mqtt_value(self.__make_topic((self.config.topic, 'schedules')), event.data)
+        elif event.event_type == EventType.SCHEDULE_VALUE and not self.config.cloud:
+            self._publish_mqtt_value(event.data.get('topic'), event.data.get('payload'))
 
     def _publish_mqtt_value(self, topic: str, payload: str, retain: bool = True):
         if not self.status():

--- a/src/setting.py
+++ b/src/setting.py
@@ -61,6 +61,7 @@ class MqttSetting(MqttSettingBase):
         self.debug_topic = 'rubix/points/debug'
         self.listen = True
         self.listen_topic = 'rubix/points/listen'
+        self.cloud = False
 
 
 class InfluxSetting(BaseSetting):

--- a/src/setting.py
+++ b/src/setting.py
@@ -53,6 +53,7 @@ class MqttSetting(MqttSettingBase):
 
     def __init__(self):
         super(MqttSetting, self).__init__()
+        self.cloud = False
         self.name = 'rubix-points'
         self.retain_clear_interval = 60
         self.publish_value = True
@@ -61,7 +62,6 @@ class MqttSetting(MqttSettingBase):
         self.debug_topic = 'rubix/points/debug'
         self.listen = True
         self.listen_topic = 'rubix/points/listen'
-        self.cloud = False
 
 
 class InfluxSetting(BaseSetting):


### PR DESCRIPTION
Resolves: #372 
### Summary:
  -  Added `cloud` field on MQTT setting (by default False).
  -  Listen to cloud broker(cloud=true) on schedule topics and publish the value on the local broker(cloud=false).