### PR TITLE
Add API for returning point-store-histories

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -44,7 +44,7 @@ def create_app(app_setting) -> Flask:
 
     def register_router(_app) -> Flask:
         from src.routes import bp_network, bp_device, bp_point, bp_generic, bp_modbus, bp_mapping_mp_gbp, bp_sync, \
-            bp_system, bp_schedule
+            bp_system, bp_schedule, bp_point_store_history
         _app.register_blueprint(bp_network)
         _app.register_blueprint(bp_device)
         _app.register_blueprint(bp_point)
@@ -54,6 +54,7 @@ def create_app(app_setting) -> Flask:
         _app.register_blueprint(bp_sync)
         _app.register_blueprint(bp_system)
         _app.register_blueprint(bp_schedule)
+        _app.register_blueprint(bp_point_store_history)
         return _app
 
     setup(app)

--- a/src/models/point/model_point_store_history.py
+++ b/src/models/point/model_point_store_history.py
@@ -1,5 +1,5 @@
 from flask import current_app
-from sqlalchemy import and_
+from sqlalchemy import and_, desc, asc
 
 from src import db
 from src.models.point.model_point_store import PointStoreModelMixin, PointStoreModel
@@ -15,12 +15,15 @@ class PointStoreHistoryModel(PointStoreModelMixin):
         return f"PointStoreHistory(point_uuid = {self.point_uuid})"
 
     @classmethod
-    def find_all(cls):
-        return cls.query.all()
+    def find_by_pagination(cls, page: int, per_page: int, sort: str):
+        sort = desc('ts_value') if sort == 'desc' else asc('ts_value')
+        return cls.query.order_by(sort).paginate(page=page, per_page=per_page, error_out=False)
 
     @classmethod
-    def find_by_point_uuid(cls, point_uuid: str):
-        return cls.query.filter_by(point_uuid=point_uuid).all()
+    def find_by_point_uuid_pagination(cls, point_uuid: str, page: int, per_page: int, sort: str):
+        sort = desc('ts_value') if sort == 'desc' else asc('ts_value')
+        return cls.query.filter_by(point_uuid=point_uuid).order_by(sort).paginate(page=page, per_page=per_page,
+                                                                                  error_out=False)
 
     def save_to_db(self):
         db.session.add(self)

--- a/src/models/point/model_point_store_history.py
+++ b/src/models/point/model_point_store_history.py
@@ -14,6 +14,14 @@ class PointStoreHistoryModel(PointStoreModelMixin):
     def __repr__(self):
         return f"PointStoreHistory(point_uuid = {self.point_uuid})"
 
+    @classmethod
+    def find_all(cls):
+        return cls.query.all()
+
+    @classmethod
+    def find_by_point_uuid(cls, point_uuid: str):
+        return cls.query.filter_by(point_uuid=point_uuid).all()
+
     def save_to_db(self):
         db.session.add(self)
         db.session.commit()

--- a/src/resources/resource_point_store_history.py
+++ b/src/resources/resource_point_store_history.py
@@ -1,0 +1,19 @@
+from flask_restful import marshal_with
+from rubix_http.resource import RubixResource
+
+from src.models.point.model_point_store_history import PointStoreHistoryModel
+from src.resources.rest_schema.schema_point_store_history import point_store_history_fields
+
+
+class PointStoryHistoryResource(RubixResource):
+    @classmethod
+    @marshal_with(point_store_history_fields)
+    def get(cls):
+        return PointStoreHistoryModel.find_all()
+
+
+class PointStoreHistoryResourceByPointUUID(RubixResource):
+    @classmethod
+    @marshal_with(point_store_history_fields)
+    def get(cls, point_uuid):
+        return PointStoreHistoryModel.find_by_point_uuid(point_uuid)

--- a/src/resources/resource_point_store_history.py
+++ b/src/resources/resource_point_store_history.py
@@ -1,19 +1,26 @@
 from flask_restful import marshal_with
+from flask_restful.reqparse import request
 from rubix_http.resource import RubixResource
 
 from src.models.point.model_point_store_history import PointStoreHistoryModel
-from src.resources.rest_schema.schema_point_store_history import point_store_history_fields
+from src.resources.rest_schema.schema_point_store_history import paginated_point_store_history_fields
 
 
 class PointStoryHistoryResource(RubixResource):
     @classmethod
-    @marshal_with(point_store_history_fields)
+    @marshal_with(paginated_point_store_history_fields)
     def get(cls):
-        return PointStoreHistoryModel.find_all()
+        page = request.args.get('page', default=None, type=int)
+        per_page = request.args.get('per_page', default=None, type=int)
+        sort = request.args.get('sort', default=None, type=str)
+        return PointStoreHistoryModel.find_by_pagination(page, per_page, sort)
 
 
 class PointStoreHistoryResourceByPointUUID(RubixResource):
     @classmethod
-    @marshal_with(point_store_history_fields)
+    @marshal_with(paginated_point_store_history_fields)
     def get(cls, point_uuid):
-        return PointStoreHistoryModel.find_by_point_uuid(point_uuid)
+        page = request.args.get('page', default=None, type=int)
+        per_page = request.args.get('per_page', default=None, type=int)
+        sort = request.args.get('sort', default=None, type=str)
+        return PointStoreHistoryModel.find_by_point_uuid_pagination(point_uuid, page, per_page, sort)

--- a/src/resources/rest_schema/schema_point_store_history.py
+++ b/src/resources/rest_schema/schema_point_store_history.py
@@ -1,0 +1,13 @@
+from flask_restful import fields
+
+point_store_history_fields = {
+    'id': fields.Integer,
+    'point_uuid': fields.String,
+    'value': fields.Float,
+    'value_original': fields.Float,
+    'value_raw': fields.String,
+    'fault': fields.Boolean,
+    'fault_message': fields.String,
+    'ts_value': fields.String,
+    'ts_fault': fields.String
+}

--- a/src/resources/rest_schema/schema_point_store_history.py
+++ b/src/resources/rest_schema/schema_point_store_history.py
@@ -11,3 +11,15 @@ point_store_history_fields = {
     'ts_value': fields.String,
     'ts_fault': fields.String
 }
+
+paginated_point_store_history_fields = {
+    "page": fields.Integer,
+    "per_page": fields.Integer,
+    "pages": fields.Integer,
+    "total": fields.Integer,
+    "has_prev": fields.Boolean,
+    "prev_num": fields.Integer,
+    "has_next": fields.Boolean,
+    "next_num": fields.Integer,
+    "items": fields.Nested(point_store_history_fields)
+}

--- a/src/routes.py
+++ b/src/routes.py
@@ -32,6 +32,7 @@ from src.drivers.modbus.resources.point.point_value_writer import ModbusPointUUI
 from src.resources.resource_device import DeviceResourceByUUID, DeviceResourceByName, DeviceResourceList
 from src.resources.resource_network import NetworkResourceByUUID, NetworkResourceByName, NetworkResourceList
 from src.resources.resource_point import PointResourceByUUID, PointResourceByName, PointResourceList
+from src.resources.resource_point_store_history import PointStoryHistoryResource, PointStoreHistoryResourceByPointUUID
 from src.resources.resource_schedule import ScheduleResourceByUUID, ScheduleResourceList, ScheduleResourceByName
 from src.system.resources.memory import GetSystemMem
 from src.system.resources.ping import Ping
@@ -114,3 +115,8 @@ api_schedule = Api(bp_schedule)
 api_schedule.add_resource(ScheduleResourceList, '')
 api_schedule.add_resource(ScheduleResourceByUUID, '/uuid/<string:uuid>')
 api_schedule.add_resource(ScheduleResourceByName, '/name/<string:name>')
+
+bp_point_store_history = Blueprint('point_store_histories', __name__, url_prefix='/api/point_store_histories')
+api_point_store_history = Api(bp_point_store_history)
+api_point_store_history.add_resource(PointStoryHistoryResource, '')
+api_point_store_history.add_resource(PointStoreHistoryResourceByPointUUID, '/point_uuid/<string:point_uuid>')


### PR DESCRIPTION
Resolves: #390
### Summary:
- Addded api endpoint for point-store histories
- Query params Default `page=1`, `per_page=20`, `sort = asc`. Example :
  -  GET `api/point_store_histories`
  -  GET `api/point_store_histories?page=1&per_page=5&sort=desc`
  -  GET `api/point_store_histories/point_uuid/<point_uuid>`
  -  GET `api/point_store_histories/point_uuid/<point_uuid>?page=1&per_page=5&sort=desc`