### PR TITLE
Improvement on update_mapping_state

### DIFF
--- a/src/drivers/modbus/models/mapping.py
+++ b/src/drivers/modbus/models/mapping.py
@@ -40,6 +40,10 @@ class MPGBPMapping(ModelBase):
         if not self.mapped_point_uuid:
             self.__set_mapped_point_uuid()
 
+    def set_uuid_with_name(self):
+        self.__set_point_uuid()
+        self.__set_mapped_point_uuid()
+
     def __set_point_name(self):
         from src.drivers.modbus.models.point import ModbusPointModel
         if not self.point_uuid:

--- a/src/drivers/modbus/resources/mapping/mapping.py
+++ b/src/drivers/modbus/resources/mapping/mapping.py
@@ -79,7 +79,10 @@ class MPGBMappingResourceUpdateMappingState(RubixResource):
                 mapping.mapping_state = MappingState.MAPPED
                 mapping.check_self()
             except ValueError:
-                mapping.mapping_state = MappingState.BROKEN
+                try:
+                    mapping.set_uuid_with_name()
+                except ValueError:
+                    mapping.mapping_state = MappingState.BROKEN
             mapping.commit()
             sync_point_value(mapping)
         return {"message": "Mapping state has been updated successfully"}


### PR DESCRIPTION
Resolves: #399 
### Summary:
- On `update_mapping_state` API endpoint updated point-uuid via name if broken, and if still name doesn't exist leave as is as broken.